### PR TITLE
Fix Documentation Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ Step 3 - Chmod cv4pve-diag to Add Persmissions to Execute cv4pve-diag:
              NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag.
 	               If you are at the Root Directory, use the Directory Path to cv4pve-diag 
 ```sh
-Example in the same Directory:
+Example Running Tool within its Directory:
 root@debian:/cv4pvediag# ./cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
+                         NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag.
 
-Example at the Root Directory:
+Example Running from the Root Directory:
 root@debian:/# /cv4pvediag/cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
+                        NOTE: If you are at the Root Directory, use the Directory Path to Run cv4pve-diag
 
 Attention: There is a Slight Delay when using the Tool due to Processing the Information. Please wait for Data to Display.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-         wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+                              wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-                                                                                              wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+                                                                                              									           wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-                              wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+                                                                  wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   For more information visit https://www.corsinvest.it/cv4pve
 
 Command Syntax:
-  cv4pve-diag [options] [command]
+  cv4pve-diag [command] [options]
 
 Options:
   --api-token <api-token>                            Api token format 'USER@REALM!TOKENID=UUID'. Require Proxmox VE 6.2 or later

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This feature permit execute Api without using user and password.
 If using **Privilege Separation** when create api token remember specify in permission.
 
 ## Configuration
+Supports Linux, Windows, OSX and ARM
 
 Install on Linux x64
 
@@ -106,8 +107,38 @@ Example at the Root Directory:
 root@debian:/# /cv4pvediag/cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
 
 ```
+```sh
+Install on Windows
 
+Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or 
+         cv4pve-diag.exe-win-x86.zip to a Directory of your Choice:
+x86 Version:                                                                           Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
+                    NOTE: Select under Assets and Choose Lastest Version
+         Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x86.zip
+                   NOTE: x.x.x is the Version Number
+         
+         x64 Version:
+         Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
+         NOTE: Select under Assets and Choose Lastest Version
+         Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x64.zip
+         NOTE: x.x.x is the Version Number  
+       
+
+Step 2 - Run the Diagnostic Tool:  
+         Example for x86 Version Running in PowerShell:         
+C:\cv4pve-diag.exe-win-x86> .\cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
+                            NOTE: The .\ in front of the Command cv4pve-diag is needed.
+                                  It is Recommened to Run the Tool in PowerShell
+                                  when Outputing in Text Mode for proper                                                 Displaying of the Data.  You can use CMD(DOS                                   Terminal) however there is a Limatation of Displaying correctly. 
+
+         Example for x86 Version Running in CMD(DOS Terminal):
+C:\cv4pve-diag.exe-win-x86> cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute 
+                            NOTE:  .\ in front of the Command cv4pve-diag is not needed.                                  
+
+Take Notice is a Slight Delay when using the Program due to Processing the Information. Please wait for Data to Display.
+```
 ```txt
+
 -------------------------------------------------------------------------------------------------------------------------------------
 | Id                             | Description                                                  | Context | SubContext   | Gravity  |
 -------------------------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-         
-	 wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+         wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or
          Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
                     NOTE: Select under Assets and Choose Lastest Version
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x86.zip
-                   NOTE: x.x.x is the Version Number
+                    NOTE: x.x.x is the Version Number
          
          x64 Version:
          Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
-         NOTE: Select under Assets and Choose Lastest Version
+                    NOTE: Select under Assets and Choose Lastest Version
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x64.zip
-         NOTE: x.x.x is the Version Number  
+                    NOTE: x.x.x is the Version Number  
        
 
 Step 2 - Run the Diagnostic Tool:  

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ C:\cv4pve-diag.exe-win-x86> .\cv4pve-diag --output=Text --host=192.168.0.100:800
 C:\cv4pve-diag.exe-win-x86> cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute 
                             NOTE:  .\ in front of the Command cv4pve-diag is not needed.                                  
 
-Attention: There is a Slight Delay when using the Program due to Processing the Information. Please wait for Data to Display.
+Attention: There is a Slight Delay when using the Tool due to Processing the Information. Please wait for Data to Display.
 ```
 ```txt
 						   OUTPUT OF CV4PVE-DIAG DATA

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-                                                                                              									           wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+                                                                                              									           
+														  wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   cv4pve-diag is a part of suite cv4pve.
   For more information visit https://www.corsinvest.it/cv4pve
 
-Command Syntax:
+Usage:
   cv4pve-diag [command] [options]
 
 Options:

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ root@debian:/# /cv4pvediag/cv4pve-diag --output=Text --host=192.168.0.100:8006 -
 Attention: There is a Slight Delay when using the Tool due to Processing the Information. Please wait for Data to Display.
 
 ```
-```sh
 Install on Windows x86 and x64
+```sh
 
 Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or 
          cv4pve-diag.exe-win-x86.zip to a Directory of your Choice:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-                                                                  wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+                                                                                              wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
          wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
-	 NOTE: x.x.x is the Version Number
+	 
+         NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 
 	 root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
 	 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x86.zip
                     NOTE: x.x.x is the Version Number
 
-                    Example for v1.4.8:      
+                    Example Option B for v1.4.8:      
 		    https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag.exe-win-x86.zip
 
          x64 Version:
@@ -132,7 +132,7 @@ Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x64.zip
                     NOTE: x.x.x is the Version Number
 
-		    Example for v1.4.8:      
+		    Example Option B for v1.4.8:      
 		    https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag.exe-win-x64.zip 
        
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or
 		    https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag.exe-win-x64.zip 
        
 
-Step 2 - Run the Diagnostic Tool:  
+Step 2 - Run the Diagnostic Tool:
+
          Example for x86 Version Running in PowerShell:         
 C:\cv4pve-diag.exe-win-x86> .\cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
                             NOTE: The .\ in front of the Command cv4pve-diag is needed.

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ If using **Privilege Separation** when create api token remember specify in perm
 
 Install on Linux x64
 
-Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
-        wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
-	
-	 NOTE: x.x.x is the Version Number
-	 Example for v1.4.8: 
-	 root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
+    Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
+             wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+	         NOTE: x.x.x is the Version Number
+	         
+	         Example for v1.4.8: 
+	         root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
 	 
 ```sh
 Step 2 - Unzip cv4pve-diag-linux-x64.zip to a Directory of your Choice:
@@ -95,9 +95,9 @@ Step 3 - Chmod cv4pve-diag to Add Persmissions to Execute cv4pve-diag:
 	 NOTE: This Allows Owner\Group\Others to Execute cv4pve-diag
 ```
 
-Step 4 - Run the Diagnostic Tool:  
-         NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag
-	       If you are at the Root Directory, use the Directory Path to cv4pve-diag 
+    Step 4 - Run the Diagnostic Tool:  
+             NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag
+	         If you are at the Root Directory, use the Directory Path to cv4pve-diag 
 ```sh
 Example in the same Directory:
 root@debian:/cv4pvediag# ./cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Install on Linux x64
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
          wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
-         NOTE: x.x.x is the Version Number
+     NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 
 	 root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
 	 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ If using **Privilege Separation** when create api token remember specify in perm
 Install on Linux x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-         wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+         
+	 wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ If using **Privilege Separation** when create api token remember specify in perm
 
 Install on Linux x64
 
-Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
-                                                                                              									           
-														  wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:                                                                                                                                                                                                                                              
+                                                                   wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
 	 
      NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,16 @@ root@debian:/cv4pvediag# ./cv4pve-diag --output=Text --host=192.168.0.100:8006 -
 Example at the Root Directory:
 root@debian:/# /cv4pvediag/cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
 
+Attention: There is a Slight Delay when using the Tool due to Processing the Information. Please wait for Data to Display.
+
 ```
 ```sh
 Install on Windows
 
 Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or 
          cv4pve-diag.exe-win-x86.zip to a Directory of your Choice:
-x86 Version:                                                                           Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
+         x86 Version:
+         Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
                     NOTE: Select under Assets and Choose Lastest Version
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x86.zip
                    NOTE: x.x.x is the Version Number
@@ -129,16 +132,17 @@ Step 2 - Run the Diagnostic Tool:
 C:\cv4pve-diag.exe-win-x86> .\cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
                             NOTE: The .\ in front of the Command cv4pve-diag is needed.
                                   It is Recommened to Run the Tool in PowerShell
-                                  when Outputing in Text Mode for proper                                                 Displaying of the Data.  You can use CMD(DOS                                   Terminal) however there is a Limatation of Displaying correctly. 
+                                  when Outputing in Text Mode for proper Displaying of the Data.
+                                  You can use CMD(DOS Terminal) however there is a Limatation of Displaying correctly. 
 
          Example for x86 Version Running in CMD(DOS Terminal):
 C:\cv4pve-diag.exe-win-x86> cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute 
                             NOTE:  .\ in front of the Command cv4pve-diag is not needed.                                  
 
-Take Notice is a Slight Delay when using the Program due to Processing the Information. Please wait for Data to Display.
+Attention: There is a Slight Delay when using the Program due to Processing the Information. Please wait for Data to Display.
 ```
 ```txt
-
+						   OUTPUT OF CV4PVE-DIAG DATA
 -------------------------------------------------------------------------------------------------------------------------------------
 | Id                             | Description                                                  | Context | SubContext   | Gravity  |
 -------------------------------------------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   cv4pve-diag is a part of suite cv4pve.
   For more information visit https://www.corsinvest.it/cv4pve
 
-Usage:
-  cv4pve-diag [command] [options]
+Command Syntax:
+  cv4pve-diag [options] [command]
 
 Options:
   --api-token <api-token>                            Api token format 'USER@REALM!TOKENID=UUID'. Require Proxmox VE 6.2 or later
@@ -77,19 +77,33 @@ If using **Privilege Separation** when create api token remember specify in perm
 
 ## Configuration
 
-E.g. install on linux 64
+Install on Linux x64
 
-Download last package e.g. Debian cv4pve-diag-linux-x64.zip, on your os and install:
-
+Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:
+         wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+	 NOTE: x.x.x is the Version Number
+	 Example for v1.4.8: 
+	 root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
+	 
 ```sh
-root@debian:~# unzip cv4pve-diag-linux-x64.zip
-root@debian:~# chmod +x cv4pve-diag 
+Step 2 - Unzip cv4pve-diag-linux-x64.zip to a Directory of your Choice:
+         root@debian:/# unzip cv4pve-diag-linux-x64.zip
+
+Step 3 - Chmod cv4pve-diag to Add Persmissions to Execute cv4pve-diag:
+         root@debian:/# chmod +x cv4pve-diag 
+	 NOTE: This Allows Owner\Group\Others to Execute cv4pve-diag
 ```
 
-This tool need basically no configuration.
-
+Step 4 - Run the Diagnostic Tool:  
+         NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag
+	       If you are at the Root Directory, use the Directory Path to cv4pve-diag 
 ```sh
-root@debian:~# cv4pve-diag --host=192.168.0.100 --username=root@pam --password=fagiano
+Example in the same Directory:
+root@debian:/cv4pvediag# ./cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
+
+Example at the Root Directory:
+root@debian:/# /cv4pvediag/cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute
+
 ```
 
 ```txt
@@ -157,7 +171,7 @@ root@debian:~# cv4pve-diag @FileParameter.parm
 File **FileParameter.parm**
 
 ```txt
---host=192.168.0.100
+--host=192.168.0.100:8006
 --username=root@pam
---password=fagiano
+--password=password
 ```

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Attention: There is a Slight Delay when using the Tool due to Processing the Inf
 
 ```
 ```sh
-Install on Windows
+Install on Windows x86 and x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or 
          cv4pve-diag.exe-win-x86.zip to a Directory of your Choice:

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Step 3 - Chmod cv4pve-diag to Add Persmissions to Execute cv4pve-diag:
 ```
 
     Step 4 - Run the Diagnostic Tool:  
-             NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag
-	         If you are at the Root Directory, use the Directory Path to cv4pve-diag 
+             NOTE: Use ./ in front of the the Command cv4pve-diag if you are in the same Directory as cv4pve-diag.
+	               If you are at the Root Directory, use the Directory Path to cv4pve-diag 
 ```sh
 Example in the same Directory:
 root@debian:/cv4pvediag# ./cv4pve-diag --output=Text --host=192.168.0.100:8006 --username=root@pam --password=password execute

--- a/README.md
+++ b/README.md
@@ -116,17 +116,24 @@ Install on Windows x86 and x64
 
 Step 1 - Download the Lastest Zip File cv4pve-diag.exe-win-x64.zip or 
          cv4pve-diag.exe-win-x86.zip to a Directory of your Choice:
+
          x86 Version:
          Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
                     NOTE: Select under Assets and Choose Lastest Version
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x86.zip
                     NOTE: x.x.x is the Version Number
-         
+
+                    Example for v1.4.8:      
+		    https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag.exe-win-x86.zip
+
          x64 Version:
          Option A - Click On File to Download: https://github.com/Corsinvest/cv4pve-diag/releases
                     NOTE: Select under Assets and Choose Lastest Version
          Option B - Direct Downlod: https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag.exe-win-x64.zip
-                    NOTE: x.x.x is the Version Number  
+                    NOTE: x.x.x is the Version Number
+
+		    Example for v1.4.8:      
+		    https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag.exe-win-x64.zip 
        
 
 Step 2 - Run the Diagnostic Tool:  

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ If using **Privilege Separation** when create api token remember specify in perm
 
 Install on Linux x64
 
-Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:                                                                                                                                                                                                                                              
-                                                                   wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
-	 
-     NOTE: x.x.x is the Version Number
+Step 1 - Download the Lastest Zip File cv4pve-diag-linux-x64.zip to a Directory of your Choice:                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
+        wget https://github.com/Corsinvest/cv4pve-diag/releases/download/x.x.x/cv4pve-diag-linux-x64.zip
+	
+	 NOTE: x.x.x is the Version Number
 	 Example for v1.4.8: 
 	 root@debian:/# wget https://github.com/Corsinvest/cv4pve-diag/releases/download/v1.4.8/cv4pve-diag-linux-x64.zip
 	 


### PR DESCRIPTION
 1. Corrected Syntax of the Command cv4pve-diag on the Banner/Logo Section
   A. Changed Usage Heading to Command Syntax
   B. Corrected Syntax to cv4pve-diag [options] [commands]

2. Provide Detailed Instructions on Installing and Running cv4pve-diag
   in the Configuration Section

3. Add Proxmox Port Number to the Execution with File Parameter Section 

4. Provided Examples
