### PR TITLE
Refactor: replace InfoHelper with direct async PveClient, v1.10.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+* text=auto eol=lf
+*.cs text eol=lf
+*.csproj text eol=lf
+*.props text eol=lf
+*.targets text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.xml text eol=lf
+*.txt text eol=lf
+*.sh text eol=lf
+
+# Binary files - no conversion
+*.png binary
+*.jpg binary
+*.ico binary
+*.zip binary
+*.nupkg binary

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.9.1</Version>
+    <Version>1.10.0</Version>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageOutputPath>..\nupkgs\</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.4" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.4" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.5" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.5" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -217,17 +217,6 @@ cv4pve-diag --host=pve.domain.com --username=root@pam --password=secret --ignore
 
 </details>
 
-<details>
-<summary><strong>Export Data</strong></summary>
-
-#### Export Collected Data
-```bash
-# Export diagnostic data to JSON file
-cv4pve-diag --host=pve.domain.com --username=root@pam --password=secret export-collect
-```
-
-</details>
-
 ### Configuration Files
 
 <details>
@@ -329,15 +318,16 @@ Create rules to ignore specific issues using regex patterns:
 ```json
 [
   {
-    "Id": "105",
+    "Id": "nodes/pve01/qemu/105",
     "Context": "Qemu",
     "SubContext": "Protection"
   }
 ]
 ```
 
-**Pattern matching:**
-- Exact match: `"Id": "105"` - ignora solo VM 105
+**Pattern matching (regex):**
+- Exact match: `"Id": "nodes/pve01/qemu/105"` - ignora solo VM 105 su pve01
+- Node match: `"Id": "nodes/pve01/.*"` - ignora tutti i problemi su pve01
 - Partial match: `"Description": ".*test.*"` - ignora se descrizione contiene "test"
 - All match: `"Id": ".*"` - ignora tutti gli ID (usa con Context/SubContext specifici)
 
@@ -379,22 +369,27 @@ Create rules to ignore specific issues using regex patterns:
 ### Example Output
 
 ```txt
------------------------------------------------------------------------------------------------------------------------------------------
-| Id                             | Description                                                  | Context | SubContext   | Gravity  |
------------------------------------------------------------------------------------------------------------------------------------------
-| pve2                           | 1 Replication has errors                                     | Node    | Replication  | Critical |
-| pve2                           | Zfs 'rpool' health problem                                   | Node    | Zfs          | Critical |
-| 312                            | Unknown resource qemu                                        | Qemu    | Status       | Critical |
-| pve3                           | Node not online                                              | Node    | Status       | Warning  |
-| local-zfs:vm-117-disk-1        | Image Orphaned                                               | Storage | Image        | Warning  |
-| 121                            | Qemu Agent not enabled                                       | Qemu    | Agent        | Warning  |
-| 103                            | cv4pve-autosnap not configured                               | Qemu    | AutoSnapshot | Warning  |
-| 115                            | vzdump backup not configured                                 | Qemu    | Backup       | Warning  |
-| 117                            | Unused disk0                                                 | Qemu    | Hardware     | Warning  |
-| 121                            | 10 snapshots older than 1 month                              | Qemu    | Snapshot     | Warning  |
-| pve1                           | 3 Update availble                                            | Node    | Update       | Info     |
-| 109                            | For more performance switch 'scsi0' hdd to VirtIO            | Qemu    | VirtIO       | Info     |
------------------------------------------------------------------------------------------------------------------------------------------
++-----------------------------+--------------------------------------------------------------------+---------+-----------------+----------+
+| Id                          | Description                                                        | Context | SubContext      | Gravity  |
++-----------------------------+--------------------------------------------------------------------+---------+-----------------+----------+
+| nodes/pve02                 | Nodes package version not equal                                    | Node    | PackageVersions | Critical |
+| nodes/pve02/qemu/203        | Disk 'scsi0' disabled for backup                                   | Qemu    | Backup          | Critical |
+| nodes/pve01/lxc/100         | Disk 'rootfs' disabled for backup                                  | Lxc     | Backup          | Critical |
+| nodes/pve01/qemu/1030       | Memory (rrd Day AVERAGE) usage 92.9% - 5.99 GB of 6.44 GB         | Qemu    | Usage           | Critical |
+| nodes/pve02                 | Nodes hosts configuration not equal                                | Node    | Hosts           | Warning  |
+| nodes/pve01/storage/local   | Image Orphaned 51.54 GB file vm-106-disk-1                         | Storage | Image           | Warning  |
+| nodes/pve01/storage/pbs01   | Storage usage 75% - 2.42 TB of 3.22 TB                            | Storage | Usage           | Warning  |
+| nodes/pve02/qemu/106        | Qemu Agent not enabled                                             | Qemu    | Agent           | Warning  |
+| nodes/pve02/qemu/999        | vzdump backup not configured                                       | Qemu    | Backup          | Warning  |
+| nodes/pve02/lxc/101         | 'cv4pve-autosnap' not configured                                   | Lxc     | AutoSnapshot    | Warning  |
+| nodes/pve01/qemu/1030       | Cdrom mounted                                                      | Qemu    | Hardware        | Warning  |
+| nodes/pve01/qemu/1010       | OS 'Microsoft Windows 10/2016/2019' not maintained from vendor!    | Qemu    | OSNotMaintained | Warning  |
+| nodes/pve01/qemu/1006       | 4 snapshots older than 1 month                                     | Qemu    | SnapshotOld     | Warning  |
+| nodes/pve01/qemu/1010       | Start on boot not enabled                                          | Qemu    | StartOnBoot     | Warning  |
+| nodes/pve02                 | 26 Update available                                                | Node    | Update          | Info     |
+| nodes/pve01/qemu/1000       | For production environment is better VM Protection = enabled       | Qemu    | Protection      | Info     |
+| nodes/pve01/qemu/1006       | For more performance switch 'net0' network to VirtIO               | Qemu    | VirtIO          | Info     |
++-----------------------------+--------------------------------------------------------------------+---------+-----------------+----------+
 ```
 
 ---
@@ -530,13 +525,6 @@ Create ignored issues template
 
 ```bash
 cv4pve-diag --host=pve.local --username=root@pam --password=secret create-ignored-issues
-```
-
-#### export-collect
-Export collected diagnostic data
-
-```bash
-cv4pve-diag --host=pve.local --username=root@pam --password=secret export-collect
 ```
 
 </details>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Application.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Application.cs
@@ -1,10 +1,10 @@
-﻿/*
+/*
  * SPDX-FileCopyrightText: Copyright Corsinvest Srl
  * SPDX-License-Identifier: GPL-3.0-only
  */
 
-using System.Diagnostics.CodeAnalysis;
-using Corsinvest.ProxmoxVE.Api.Extension.Utils;
+using Corsinvest.ProxmoxVE.Api;
+using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Common;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
@@ -19,29 +19,38 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 public class Application
 {
     /// <summary>
-    /// Analyze
+    /// Analyze cluster by querying PVE API directly
     /// </summary>
-    /// <param name="info"></param>
-    /// <param name="settings"></param>
-    /// <param name="ignoredIssues"></param>
-    /// <returns></returns>
-    public static ICollection<DiagnosticResult> Analyze(InfoHelper.Info info,
-                                                        Settings settings,
-                                                        List<DiagnosticResult> ignoredIssues)
+    public static async Task<ICollection<DiagnosticResult>> AnalyzeAsync(PveClient client,
+                                                                         Settings settings,
+                                                                         List<DiagnosticResult> ignoredIssues)
     {
         var result = new List<DiagnosticResult>();
-        if (info == null) { return result; }
+        var now = DateTime.Now;
 
-        CheckUnknown(result, info);
+        var allResources = await client.Cluster.Resources.GetAsync();
+        var resources = allResources.Where(a => !a.IsUnknown).ToList();
 
-        var resources = info.Cluster.Resources.Where(a => !a.IsUnknown);
+        // Unknown resources
+        result.AddRange(allResources.Where(a => a.IsUnknown)
+                                    .Select(a => new DiagnosticResult
+                                    {
+                                        Id = a.GetWebUrl(),
+                                        ErrorCode = "CU0001",
+                                        Description = $"Unknown resource {a.Type}",
+                                        Context = DiagnosticResult.DecodeContext(a.Type),
+                                        SubContext = "Status",
+                                        Gravity = DiagnosticResultGravity.Critical,
+                                    }));
 
-        CheckStorage(info, result, resources, settings);
-        CheckNode(info, result, resources, settings);
-        CheckQemu(info, result, resources, settings);
-        CheckLxc(info, result, resources, settings);
+        var clusterConfigNodes = await client.Cluster.Config.Nodes.GetAsync();
+        var clusterBackups = await client.Cluster.Backup.GetAsync();
 
-        //filter with ignore
+        await CheckStorageAsync(client, result, resources, settings, now);
+        await CheckNodesAsync(client, result, resources, settings, clusterConfigNodes.Any(), now);
+        await CheckQemuAsync(client, result, resources, settings, clusterBackups, now);
+        await CheckLxcAsync(client, result, resources, settings, clusterBackups, now);
+
         foreach (var ignoredIssue in ignoredIssues)
         {
             foreach (var item in result.Where(a => ignoredIssue.CheckIgnoreIssue(a)))
@@ -53,47 +62,24 @@ public class Application
         return result;
     }
 
-    private static void CheckUnknown(List<DiagnosticResult> result, InfoHelper.Info info)
-        => result.AddRange(info.Cluster.Resources
-                                       .Where(a => a.IsUnknown)
-                                       .Select(a => new DiagnosticResult
-                                       {
-                                           Id = a.Id,
-                                           ErrorCode = "CU0001",
-                                           Description = $"Unknown resource {a.Type}",
-                                           Context = DiagnosticResult.DecodeContext(a.Type),
-                                           SubContext = "Status",
-                                           Gravity = DiagnosticResultGravity.Critical,
-                                       }));
+    private record StorageContent(string Id,
+                                  string Volume,
+                                  string Storage,
+                                  long VmId,
+                                  string FileName,
+                                  long Size);
 
-    class NodeStorageContentComparer : IEqualityComparer<NodeStorageContent>
+    private static async Task CheckStorageAsync(PveClient client,
+                                                List<DiagnosticResult> result,
+                                                List<ClusterResource> resources,
+                                                Settings settings,
+                                                DateTime now)
     {
-        public bool Equals(NodeStorageContent? x, NodeStorageContent? y)
-        {
-            if (x is null || y is null) return x is null && y is null;
-            return x.Volume == y.Volume;
-        }
-
-        public int GetHashCode([DisallowNull] NodeStorageContent obj)
-        {
-            if (obj == null) { return 0; }
-            var NameHashCode = obj.Volume == null
-                                ? 0
-                                : obj.Volume.GetHashCode();
-            return obj.Volume!.GetHashCode() ^ NameHashCode;
-        }
-    }
-
-    private static void CheckStorage(InfoHelper.Info info,
-                                     List<DiagnosticResult> result,
-                                     IEnumerable<ClusterResource> resources,
-                                     Settings settings)
-    {
-        //storage
+        // storage not available
         result.AddRange(resources.Where(a => a.ResourceType == ClusterResourceType.Storage && !a.IsAvailable)
                                  .Select(a => new DiagnosticResult
                                  {
-                                     Id = a.Id,
+                                     Id = a.GetWebUrl(),
                                      ErrorCode = "CS0001",
                                      Description = "Storage not available",
                                      Context = DiagnosticResultContext.Storage,
@@ -101,64 +87,65 @@ public class Application
                                      Gravity = DiagnosticResultGravity.Critical,
                                  }));
 
-        //storage usage
+        // storage usage
         CheckThreshold(result,
                        settings.Storage.Threshold,
                        "CS0001",
                        DiagnosticResultContext.Storage,
                        "Usage",
                        resources.Where(a => a.ResourceType == ClusterResourceType.Storage && a.IsAvailable)
-                                .Select(a =>
-                                (
-                                    Convert.ToDouble(a.DiskUsage),
-                                    Convert.ToDouble(a.DiskSize),
-                                    a.Storage,
-                                    "Storage"
-                                )),
+                                .Select(a => new ThresholdDataPoint(Convert.ToDouble(a.DiskUsage),
+                                                                    Convert.ToDouble(a.DiskSize),
+                                                                    a.GetWebUrl(),
+                                                                    "Storage")),
                        false,
                        true);
 
         #region Orphaned Images
-        //images in storage
-        var storagesImages = new List<NodeStorageContent>();
+        var storagesImages = new List<StorageContent>();
         foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Storage
+                                                  && a.Content != null
                                                   && a.Content.Split(",").Contains("images")))
         {
-            var node = GetNode(info, item.Node);
-            var content = node.Storages.Where(a => a.Detail.Storage == item.Storage
-                                                   && a.Detail.Content.Split(",").Contains("images"))
-                                       .SelectMany(a => a.Content)
-                                       .Where(a => a.Content == "images");
-            storagesImages.AddRange(content);
+            var nodeApi = client.Nodes[item.Node];
+            var nodeStorages = await nodeApi.Storage.GetAsync();
+            foreach (var ns in nodeStorages.Where(a => a.Storage == item.Storage
+                                                       && a.Content != null
+                                                       && a.Content.Split(",").Contains("images")
+                                                       && a.Active))
+            {
+                var content = await nodeApi.Storage[ns.Storage].Content.GetAsync();
+                storagesImages.AddRange([.. content.Where(a => a.Content == "images")
+                                                   .Select(a => new StorageContent(item.GetWebUrl(),
+                                                                                   a.Volume,
+                                                                                   ns.Storage,
+                                                                                   a.VmId,
+                                                                                   a.FileName,
+                                                                                   a.Size))]);
+            }
         }
 
-        storagesImages = [.. storagesImages.Distinct(new NodeStorageContentComparer())];
+        // deduplicate
+        storagesImages = [.. storagesImages.DistinctBy(a => a.Volume)];
 
         foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Vm))
         {
-            var node = GetNode(info, item.Node);
-            var config = item.VmType switch
-            {
-                VmType.Qemu => node.Qemu.First(a => a.Detail.VmId == item.VmId).Config,
-                VmType.Lxc => (VmConfig)node.Lxc.First(a => a.Detail.VmId == item.VmId).Config,
-                _ => throw new ArgumentOutOfRangeException(nameof(resources)),
-            };
+            var nodeApi = client.Nodes[item.Node];
+            VmConfig config = item.VmType == VmType.Qemu
+                                ? await nodeApi.Qemu[item.VmId].Config.GetAsync()
+                                : await nodeApi.Lxc[item.VmId].Config.GetAsync();
 
-            //check disk exists
             foreach (var disk in config.Disks)
             {
-                var images = storagesImages.Where(a => a.VmId == item.VmId
-                                                       && a.Storage == disk.Storage
-                                                       && a.FileName == disk.FileName)
-                                           .ToArray();
-
-                foreach (var image in images) { storagesImages.Remove(image); }
+                storagesImages.RemoveAll(a => a.VmId == item.VmId
+                                              && a.Storage == disk.Storage
+                                              && a.FileName == disk.FileName);
             }
         }
 
         result.AddRange(storagesImages.Select(a => new DiagnosticResult
         {
-            Id = a.Storage,
+            Id = a.Id,
             ErrorCode = "WN0001",
             Description = $"Image Orphaned {FormatHelper.FromBytes(a.Size)} file {a.FileName}",
             Context = DiagnosticResultContext.Storage,
@@ -168,35 +155,50 @@ public class Application
         #endregion
     }
 
-    private static InfoHelper.Info.NodeInfo GetNode(InfoHelper.Info info, string node) => info.Nodes.FirstOrDefault(a => a.Detail.Node == node)!;
+    private record NodeCompareData(NodeVersion Version,
+                                   string[] Hosts,
+                                   NodeDns Dns,
+                                   string Timezone,
+                                   IEnumerable<NodeAptVersion> AptVersions);
 
-    private static void CheckNode(InfoHelper.Info info,
-                                  List<DiagnosticResult> result,
-                                  IEnumerable<ClusterResource> resources,
-                                  Settings settings)
+    private static async Task CheckNodesAsync(PveClient client,
+                                              List<DiagnosticResult> result,
+                                              List<ClusterResource> resources,
+                                              Settings settings,
+                                              bool hasCluster,
+                                              DateTime now)
     {
-        var nodes = resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline);
-        var hasCluster = info.Cluster.Config.Nodes.Any();
+        var endOfLife = new Dictionary<int, DateTime>
+        {
+            { 7, new DateTime(2024, 07, 01) },
+            { 6, new DateTime(2022, 09, 01) },
+            { 5, new DateTime(2020, 07, 01) },
+            { 4, new DateTime(2018, 06, 01) },
+        };
 
-        var endOfLife = new Dictionary<int, DateTime>()
-                        {
-                            {7 , new DateTime(2024,07,01)},
-                            {6 , new DateTime(2022,09,01)},
-                            {5 , new DateTime(2020,07,01)},
-                            {4 , new DateTime(2018,06,01)},
-                        };
+        var onlineNodes = resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline).ToList();
 
-        //node
+        // collect lightweight data for cross-node comparisons
+        var nodeCompareData = new Dictionary<string, NodeCompareData>();
+        foreach (var item in onlineNodes)
+        {
+            var api = client.Nodes[item.Node];
+            nodeCompareData[item.Node] = new NodeCompareData(await api.Version.GetAsync(),
+                                                             ((string)(await api.Hosts.GetEtcHosts()).ToData().data).Split('\n'),
+                                                             await api.Dns.GetAsync(),
+                                                             (await api.Time.Time()).ToData().timezone as string ?? string.Empty,
+                                                             await api.Apt.Versions.GetAsync());
+        }
+
         foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Node))
         {
-            var errorId = item.Node;
-            var node = GetNode(info, item.Node);
+            var id = item.GetWebUrl();
 
             if (!item.IsOnline)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WN0001",
                     Description = "Node not online",
                     Context = DiagnosticResultContext.Node,
@@ -206,16 +208,18 @@ public class Application
                 continue;
             }
 
-            #region End Of Life
-            var nodeVersion = int.Parse(node.Version.Version.Split(".")[0]);
+            var nodeApi = client.Nodes[item.Node];
+            var (version, hosts, dns, timezone, aptVersions) = nodeCompareData[item.Node];
+            if (!int.TryParse(version.Version?.Split(".")[0], out var nodeVersion)) { continue; }
 
-            if (endOfLife.TryGetValue(nodeVersion, out var eolDate) && DateTime.Now.Date >= eolDate)
+            #region End Of Life
+            if (endOfLife.TryGetValue(nodeVersion, out var eolDate) && now.Date >= eolDate)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WN0001",
-                    Description = $"Version {node.Version.Version} end of life {eolDate}",
+                    Description = $"Version {version.Version} end of life {eolDate}",
                     Context = DiagnosticResultContext.Node,
                     SubContext = "EOL",
                     Gravity = DiagnosticResultGravity.Warning,
@@ -224,11 +228,12 @@ public class Application
             #endregion
 
             #region Subscription
-            if (node.Subscription.Status.ToLower() != "active")
+            var subscription = await nodeApi.Subscription.GetAsync();
+            if (!subscription.Status.Equals("active", StringComparison.CurrentCultureIgnoreCase))
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WN0001",
                     Description = "Node not have subscription active",
                     Context = DiagnosticResultContext.Node,
@@ -241,26 +246,26 @@ public class Application
             #region RrdData
             var rrdData = settings.Node.TimeSeries switch
             {
-                SettingsTimeSeriesType.Day => node.RrdData.Day,
-                SettingsTimeSeriesType.Week => node.RrdData.Week,
+                SettingsTimeSeriesType.Day => await nodeApi.Rrddata.GetAsync(RrdDataTimeFrame.Day, RrdDataConsolidation.Average),
+                SettingsTimeSeriesType.Week => await nodeApi.Rrddata.GetAsync(RrdDataTimeFrame.Week, RrdDataConsolidation.Average),
                 _ => throw new ArgumentOutOfRangeException("settings.Node.TimeSeries"),
             };
 
-            CheckNodeRrd(result, settings, errorId, rrdData);
+            CheckNodeRrd(result, settings, id, rrdData);
             #endregion
 
-            #region Check nodes difference
+            #region Cross-node comparisons
             var checkInNodes = new bool[] { true, true, true, true };
-            foreach (var itemOtherNode in nodes)
+            foreach (var other in onlineNodes.Where(a => a.Node != item.Node))
             {
-                var otherNode = GetNode(info, itemOtherNode.Node);
+                if (!nodeCompareData.TryGetValue(other.Node, out var otherData)) { continue; }
+                var (otherVersion, otherHosts, otherDns, otherTimezone, otherAptVersions) = otherData;
 
-                //version
-                if (checkInNodes[0] && !node.Version.IsEqual(otherNode.Version))
+                if (checkInNodes[0] && !version.IsEqual(otherVersion))
                 {
                     result.Add(new DiagnosticResult
                     {
-                        Id = errorId,
+                        Id = id,
                         ErrorCode = "WN0001",
                         Description = "Nodes version not equal",
                         Context = DiagnosticResultContext.Node,
@@ -270,12 +275,11 @@ public class Application
                     checkInNodes[0] = false;
                 }
 
-                //hosts files
-                if (checkInNodes[1] && string.Join("", node.Hosts) != string.Join("", otherNode.Hosts))
+                if (checkInNodes[1] && string.Join("", hosts) != string.Join("", otherHosts))
                 {
                     result.Add(new DiagnosticResult
                     {
-                        Id = errorId,
+                        Id = id,
                         ErrorCode = "WN0001",
                         Description = "Nodes hosts configuration not equal",
                         Context = DiagnosticResultContext.Node,
@@ -285,12 +289,11 @@ public class Application
                     checkInNodes[1] = false;
                 }
 
-                //DNS
-                if (checkInNodes[2] && !node.Dns.IsEqual(otherNode.Dns))
+                if (checkInNodes[2] && !dns.IsEqual(otherDns))
                 {
                     result.Add(new DiagnosticResult
                     {
-                        Id = errorId,
+                        Id = id,
                         ErrorCode = "WN0001",
                         Description = "Nodes DNS not equal",
                         Context = DiagnosticResultContext.Node,
@@ -300,12 +303,11 @@ public class Application
                     checkInNodes[2] = false;
                 }
 
-                //timezone
-                if (checkInNodes[3] && node.Timezone != otherNode.Timezone)
+                if (checkInNodes[3] && timezone != otherTimezone)
                 {
                     result.Add(new DiagnosticResult
                     {
-                        Id = errorId,
+                        Id = id,
                         ErrorCode = "WN0001",
                         Description = "Nodes Timezone not equal",
                         Context = DiagnosticResultContext.Node,
@@ -318,36 +320,34 @@ public class Application
             #endregion
 
             #region Network Card
-            result.AddRange(node.Network.Where(a => a.Type == "eth" && !a.Active)
-                                        .Select(a => new DiagnosticResult
-                                        {
-                                            Id = errorId,
-                                            ErrorCode = "WN0002",
-                                            Description = $"Network card '{a.Interface}' not active",
-                                            Context = DiagnosticResultContext.Node,
-                                            SubContext = "Network",
-                                            Gravity = DiagnosticResultGravity.Warning,
-                                        }));
+            result.AddRange((await nodeApi.Network.GetAsync())
+                            .Where(a => a.Type == "eth" && !a.Active)
+                            .Select(a => new DiagnosticResult
+                            {
+                                Id = id,
+                                ErrorCode = "WN0002",
+                                Description = $"Network card '{a.Interface}' not active",
+                                Context = DiagnosticResultContext.Node,
+                                SubContext = "Network",
+                                Gravity = DiagnosticResultGravity.Warning,
+                            }));
             #endregion
 
             #region Package Versions
             var addErrPackageVersions = false;
-            foreach (var itemOtherNode in nodes)
+            foreach (var other in onlineNodes.Where(a => a.Node != item.Node))
             {
                 if (addErrPackageVersions) { break; }
-
-                var otherNode = GetNode(info, itemOtherNode.Node);
-
-                foreach (var pkg in node.Apt.Version)
+                if (!nodeCompareData.TryGetValue(other.Node, out var otherPkgData)) { continue; }
+                var (_, _, _, _, otherAptVersions) = otherPkgData;
+                foreach (var pkg in aptVersions)
                 {
-                    if (!otherNode.Apt.Version.Any(a => a.Version == pkg.Version
-                                                        && a.Title == pkg.Title
-                                                        && a.Package == pkg.Package))
+                    if (!otherAptVersions.Any(a => a.Version == pkg.Version && a.Title == pkg.Title && a.Package == pkg.Package))
                     {
                         addErrPackageVersions = true;
                         result.Add(new DiagnosticResult
                         {
-                            Id = errorId,
+                            Id = id,
                             ErrorCode = "WN0001",
                             Description = "Nodes package version not equal",
                             Context = DiagnosticResultContext.Node,
@@ -363,100 +363,45 @@ public class Application
             #region Services
             var serviceExcluded = new List<string>();
             if (!hasCluster) { serviceExcluded.Add("corosync"); }
+            serviceExcluded.Add(nodeVersion >= 7
+                                    ? "systemd-timesyncd"
+                                    : "chrony");
 
-            //see https://pve.proxmox.com/wiki/Time_Synchronization
-            serviceExcluded.Add(nodeVersion >= 7 ? "systemd-timesyncd" : "chrony");
-
-            result.AddRange(node.Services.Where(a => !a.IsRunning && !serviceExcluded.Contains(a.Name))
-                                         .Select(a => new DiagnosticResult
-                                         {
-                                             Id = errorId,
-                                             ErrorCode = "WN0002",
-                                             Description = $"Service '{a.Description}' not running",
-                                             Context = DiagnosticResultContext.Node,
-                                             SubContext = "Service",
-                                             Gravity = DiagnosticResultGravity.Warning,
-                                         }));
+            result.AddRange((await nodeApi.Services.GetAsync())
+                            .Where(a => !a.IsRunning && !serviceExcluded.Contains(a.Name))
+                            .Select(a => new DiagnosticResult
+                            {
+                                Id = id,
+                                ErrorCode = "WN0002",
+                                Description = $"Service '{a.Description}' not running",
+                                Context = DiagnosticResultContext.Node,
+                                SubContext = "Service",
+                                Gravity = DiagnosticResultGravity.Warning,
+                            }));
             #endregion
 
             #region Certificates
-            result.AddRange(node.Certificates
-                                .Where(a => DateTimeOffset.FromUnixTimeSeconds(a.NotAfter) < info.Date)
-                                .Select(a => new DiagnosticResult
-                                {
-                                    Id = errorId,
-                                    ErrorCode = "WN0002",
-                                    Description = $"Certificate '{a.FileName}' expired",
-                                    Context = DiagnosticResultContext.Node,
-                                    SubContext = "Certificates",
-                                    Gravity = DiagnosticResultGravity.Critical,
-                                }));
+            result.AddRange((await nodeApi.Certificates.Info.GetAsync())
+                              .Where(a => DateTimeOffset.FromUnixTimeSeconds(a.NotAfter) < now)
+                              .Select(a => new DiagnosticResult
+                              {
+                                  Id = id,
+                                  ErrorCode = "WN0002",
+                                  Description = $"Certificate '{a.FileName}' expired",
+                                  Context = DiagnosticResultContext.Node,
+                                  SubContext = "Certificates",
+                                  Gravity = DiagnosticResultGravity.Critical,
+                              }));
             #endregion
 
-            // //Ceph
-            // if (item.Detail.Ceph.Config != null)
-            // {
-            //     //Cluster
-            //     if (item.Detail.Ceph.Status.health.status.Value != "HEALTH_OK")
-            //     {
-            //         result.Add(new DiagnosticResult
-            //         {
-            //             Id = errorId,
-            //             ErrorCode = "IN0001",
-            //             Description = $"Ceph status '{item.Detail.Ceph.Status.health.status.Value}'",
-            //             Context = DiagnosticResultContext.Node,
-            //             SubContext = "Ceph",
-            //             Gravity = item.Detail.Ceph.Status.health.status.Value == "HEALTH_WARN" ?
-            //                         DiagnosticResultGravity.Critical :
-            //                         DiagnosticResultGravity.Warning
-            //         });
-            //     }
-
-            //     //PGs active+clean
-            //     if (((IEnumerable<dynamic>)item.Detail.Ceph.Status.pgmap.pgs_by_state)
-            //             .Where(a => a.state_name == "active+clean").Count() == 0)
-            //     {
-            //         result.Add(new DiagnosticResult
-            //         {
-            //             Id = errorId,
-            //             ErrorCode = "IN0001",
-            //             Description = "Ceph PGs not active+clean",
-            //             Context = DiagnosticResultContext.Node,
-            //             SubContext = "Ceph",
-            //             Gravity = DiagnosticResultGravity.Warning
-            //         });
-            //     }
-
-            //     //Osd
-            //     void OsdRic(IEnumerable<dynamic> children)
-            //     {
-            //         result.AddRange(children.Where(a => a.type == "osd" && a.status != "up" && a.host == item.node)
-            //                         .Select(a => new DiagnosticResult
-            //                         {
-            //                             Id = errorId,
-            //                             ErrorCode = "WN0002",
-            //                             Description = $"Osd '{a.name}' not up",
-            //                             Context = DiagnosticResultContext.Node,
-            //                             SubContext = "Ceph",
-            //                             Gravity = DiagnosticResultGravity.Critical,
-            //                         }));
-
-            //         foreach (var item in children)
-            //         {
-            //             if (item.children != null) { OsdRic(item.children); }
-            //         }
-            //     }
-            //     OsdRic(item.Detail.Ceph.Osd.root.children);
-            // }
-
             #region Replication
-            var replCount = node.Replication.Count(a => a.ExtensionData != null
-                                                        && a.ExtensionData.ContainsKey("errors"));
+            var replCount = (await nodeApi.Replication.GetAsync())
+                                .Count(a => a.ExtensionData != null && a.ExtensionData.ContainsKey("errors"));
             if (replCount > 0)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "IN0001",
                     Description = $"{replCount} Replication has errors",
                     Context = DiagnosticResultContext.Node,
@@ -466,15 +411,16 @@ public class Application
             }
             #endregion
 
-            CheckNodeDisk(result, settings, node, errorId);
+            await CheckNodeDiskAsync(nodeApi, result, settings, id);
 
-            #region Update
-            var updateCount = node.Apt.Update.Count();
+            #region APT Updates
+            var aptUpdate = await nodeApi.Apt.Update.GetAsync();
+            var updateCount = aptUpdate.Count();
             if (updateCount > 0)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "IN0001",
                     Description = $"{updateCount} Update available",
                     Context = DiagnosticResultContext.Node,
@@ -482,15 +428,13 @@ public class Application
                     Gravity = DiagnosticResultGravity.Info,
                 });
             }
-            #endregion
 
-            #region Update Important
-            var updateImportantCount = node.Apt.Update.Count(a => a.Priority == "important");
+            var updateImportantCount = aptUpdate.Count(a => a.Priority == "important");
             if (updateImportantCount > 0)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "IN0001",
                     Description = $"{updateImportantCount} Update Important available",
                     Context = DiagnosticResultContext.Node,
@@ -500,130 +444,107 @@ public class Application
             }
             #endregion
 
-            //task history
-            CheckTaskHistory(result, node.Tasks, DiagnosticResultContext.Node, errorId);
+            #region Task history
+            var dayTask = new DateTimeOffset(now.AddDays(-2)).ToUnixTimeSeconds();
+            var tasks = (await nodeApi.Tasks.GetAsync(errors: true, limit: 1000)).Where(a => a.StartTime >= dayTask);
+            CheckTaskHistory(result, tasks, DiagnosticResultContext.Node, id);
+            #endregion
         }
     }
 
-    private static void CheckNodeDisk(List<DiagnosticResult> result,
-                                      Settings settings,
-                                      InfoHelper.Info.NodeInfo node,
-                                      string id)
+    private static async Task CheckNodeDiskAsync(PveClient.PveNodes.PveNodeItem nodeApi,
+                                                 List<DiagnosticResult> result,
+                                                 Settings settings,
+                                                 string id)
     {
         #region Disks
-        result.AddRange(node.Disks.List.Where(a => a.Disk.Health != "PASSED" && a.Disk.Health != "OK")
-                                       .Select(a => new DiagnosticResult
-                                       {
-                                           Id = id,
-                                           ErrorCode = "CN0003",
-                                           Description = $"Disk '{a.Disk.DevPath}' S.M.A.R.T. status problem",
-                                           Context = DiagnosticResultContext.Node,
-                                           SubContext = "S.M.A.R.T.",
-                                           Gravity = DiagnosticResultGravity.Warning,
-                                       }));
-        #endregion
+        var disksAll = await nodeApi.Disks.List.GetAsync(include_partitions: false);
 
-        #region Sdd Wearout N/A
-        result.AddRange(node.Disks.List.Where(a => a.Disk.IsSsd && a.Disk.Wearout == "N/A")
-                                       .Select(a => new DiagnosticResult
-                                       {
-                                           Id = id,
-                                           ErrorCode = "CN0003",
-                                           Description = $"Disk ssd '{a.Disk.DevPath}' wearout not valid.",
-                                           Context = DiagnosticResultContext.Node,
-                                           SubContext = "SSD Wearout",
-                                           Gravity = DiagnosticResultGravity.Warning,
-                                       }));
-        #endregion
+        result.AddRange(disksAll.Where(a => a.Health != "PASSED" && a.Health != "OK")
+                                .Select(a => new DiagnosticResult
+                                {
+                                    Id = id,
+                                    ErrorCode = "CN0003",
+                                    Description = $"Disk '{a.DevPath}' S.M.A.R.T. status problem",
+                                    Context = DiagnosticResultContext.Node,
+                                    SubContext = "S.M.A.R.T.",
+                                    Gravity = DiagnosticResultGravity.Warning,
+                                }));
 
-        #region Sdd Wearout not in range
+        result.AddRange(disksAll.Where(a => a.IsSsd && a.Wearout == "N/A")
+                                .Select(a => new DiagnosticResult
+                                {
+                                    Id = id,
+                                    ErrorCode = "CN0003",
+                                    Description = $"Disk ssd '{a.DevPath}' wearout not valid.",
+                                    Context = DiagnosticResultContext.Node,
+                                    SubContext = "SSD Wearout",
+                                    Gravity = DiagnosticResultGravity.Warning,
+                                }));
+
         CheckThreshold(result,
                        settings.SsdWearoutThreshold,
                        "CN0003",
                        DiagnosticResultContext.Node,
                        "SSD Wearout",
-                       node.Disks.List.Where(a => a.Disk.IsSsd && a.Disk.Wearout != "N/A")
-                                      .Select(a =>
-                                      (
-                                            100.0 - Convert.ToDouble(a.Disk.Wearout),
-                                            0d,
-                                            id,
-                                            $"SSD '{a.Disk.DevPath}'"
-                                      )),
+                       disksAll.Where(a => a.IsSsd && a.Wearout != "N/A")
+                               .Select(a => new ThresholdDataPoint(100.0 - Convert.ToDouble(a.Wearout), 0d, id, $"SSD '{a.DevPath}'")),
                        true,
                        false);
         #endregion
 
         #region Zfs
-        result.AddRange(node.Disks.Zfs.Where(a => a.Zfs.Health != "ONLINE")
-                                      .Select(a => new DiagnosticResult
-                                      {
-                                          Id = id,
-                                          ErrorCode = "CN0003",
-                                          Description = $"Zfs '{a.Zfs.Name}' health problem {a.Zfs.Health}",
-                                          Context = DiagnosticResultContext.Node,
-                                          SubContext = "Zfs",
-                                          Gravity = DiagnosticResultGravity.Critical,
-                                      }));
-        #endregion
+        var zfsList = await nodeApi.Disks.Zfs.GetAsync() ?? [];
 
-        #region Zfs used
+        result.AddRange(zfsList.Where(a => a.Health != "ONLINE")
+                               .Select(a => new DiagnosticResult
+                               {
+                                   Id = id,
+                                   ErrorCode = "CN0003",
+                                   Description = $"Zfs '{a.Name}' health problem {a.Health}",
+                                   Context = DiagnosticResultContext.Node,
+                                   SubContext = "Zfs",
+                                   Gravity = DiagnosticResultGravity.Critical,
+                               }));
+
         CheckThreshold(result,
                        settings.Storage.Threshold,
                        "CS0001",
                        DiagnosticResultContext.Storage,
                        "Zfs",
-                       node.Disks.Zfs.Select(a =>
-                       (
-                            Convert.ToDouble(a.Zfs.Alloc),
-                            Convert.ToDouble(a.Zfs.Size),
-                            $"{id} ({a.Zfs.Name})",
-                            $"Zfs '{a.Zfs.Name}'"
-                       )),
+                       zfsList.Select(a => new ThresholdDataPoint(Convert.ToDouble(a.Alloc),
+                                                                  Convert.ToDouble(a.Size),
+                                                                  $"{id} ({a.Name})",
+                                                                  $"Zfs '{a.Name}'")),
                        false,
                        true);
         #endregion
     }
 
-    private static void CheckLxc(InfoHelper.Info info,
-                                 List<DiagnosticResult> result,
-                                 IEnumerable<ClusterResource> resources,
-                                 Settings settings)
-    {
-        foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Vm
-                                                    && a.VmType == VmType.Lxc
-                                                    && !a.IsTemplate))
-        {
-            var node = GetNode(info, item.Node);
-            var vm = node.Lxc.FirstOrDefault(a => a.Detail.VmId == item.VmId);
-            if (vm != null)
-            {
-                CheckCommonVm(info, result, settings.Lxc, vm, DiagnosticResultContext.Lxc, node, item.VmId.ToString());
-            }
-        }
-    }
-
-    private static void CheckQemu(InfoHelper.Info info,
-                                  List<DiagnosticResult> result,
-                                  IEnumerable<ClusterResource> resources,
-                                  Settings settings)
+    private static async Task CheckQemuAsync(PveClient client,
+                                             List<DiagnosticResult> result,
+                                             List<ClusterResource> resources,
+                                             Settings settings,
+                                             IEnumerable<ClusterBackup> clusterBackups,
+                                             DateTime now)
     {
         var osNotMaintained = new[] { "win10", "win8", "win7", "w2k8", "wxp", "w2k" };
 
         foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Vm
-                                                      && a.VmType == VmType.Qemu
-                                                      && !a.IsTemplate))
+                                                  && a.VmType == VmType.Qemu
+                                                  && !a.IsTemplate))
         {
-            var node = GetNode(info, item.Node);
-            var vm = node.Qemu.FirstOrDefault(a => a.Detail.VmId == item.VmId)!;
-            var errorId = item.VmId.ToString();
+            var nodeApi = client.Nodes[item.Node];
+            var vmApi = nodeApi.Qemu[item.VmId];
+            var id = item.GetWebUrl();
+            var config = await vmApi.Config.GetAsync();
 
-            #region Check version OS
-            if (vm.Config.OsType == null)
+            #region OS
+            if (config.OsType == null)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
                     Description = "OsType not set!",
                     Context = DiagnosticResultContext.Qemu,
@@ -631,13 +552,13 @@ public class Application
                     Gravity = DiagnosticResultGravity.Critical,
                 });
             }
-            else if (osNotMaintained.Contains(vm.Config.OsType))
+            else if (osNotMaintained.Contains(config.OsType))
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
-                    Description = $"OS '{vm.Config.OsTypeDecode}' not maintained from vendor!",
+                    Description = $"OS '{config.OsTypeDecode}' not maintained from vendor!",
                     Context = DiagnosticResultContext.Qemu,
                     SubContext = "OSNotMaintained",
                     Gravity = DiagnosticResultGravity.Warning,
@@ -646,11 +567,11 @@ public class Application
             #endregion
 
             #region Agent
-            if (!vm.Config.AgentEnabled)
+            if (!config.AgentEnabled)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
                     Description = "Qemu Agent not enabled",
                     Context = DiagnosticResultContext.Qemu,
@@ -658,27 +579,44 @@ public class Application
                     Gravity = DiagnosticResultGravity.Warning,
                 });
             }
-            else if (item.IsRunning && string.IsNullOrWhiteSpace(vm.Agent.GetHostName?.Result?.HostName))
+            else if (item.IsRunning)
             {
-                //agent in quest
-                result.Add(new DiagnosticResult
+                try
                 {
-                    Id = errorId,
-                    ErrorCode = "WV0001",
-                    Description = "Qemu Agent in guest not running",
-                    Context = DiagnosticResultContext.Qemu,
-                    SubContext = "Agent",
-                    Gravity = DiagnosticResultGravity.Warning,
-                });
+                    var agentHost = await vmApi.Agent.GetHostName.GetAsync();
+                    if (string.IsNullOrWhiteSpace(agentHost?.Result?.HostName))
+                    {
+                        result.Add(new DiagnosticResult
+                        {
+                            Id = id,
+                            ErrorCode = "WV0001",
+                            Description = "Qemu Agent in guest not running",
+                            Context = DiagnosticResultContext.Qemu,
+                            SubContext = "Agent",
+                            Gravity = DiagnosticResultGravity.Warning,
+                        });
+                    }
+                }
+                catch
+                {
+                    result.Add(new DiagnosticResult
+                    {
+                        Id = id,
+                        ErrorCode = "WV0001",
+                        Description = "Qemu Agent in guest not running",
+                        Context = DiagnosticResultContext.Qemu,
+                        SubContext = "Agent",
+                        Gravity = DiagnosticResultGravity.Warning,
+                    });
+                }
             }
             #endregion
 
-            #region Start on boot
-            if (!vm.Config.OnBoot)
+            if (!config.OnBoot)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
                     Description = "Start on boot not enabled",
                     Context = DiagnosticResultContext.Qemu,
@@ -686,14 +624,12 @@ public class Application
                     Gravity = DiagnosticResultGravity.Warning,
                 });
             }
-            #endregion
 
-            #region Protection
-            if (!vm.Config.Protection)
+            if (!config.Protection)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
                     Description = "For production environment is better VM Protection = enabled",
                     Context = DiagnosticResultContext.Qemu,
@@ -701,87 +637,80 @@ public class Application
                     Gravity = DiagnosticResultGravity.Info,
                 });
             }
-            #endregion
 
-            #region Lock
-            if (vm.Config.IsLocked)
+            if (config.IsLocked)
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
-                    Description = $"VM is locked by '{vm.Config.Lock}'",
+                    Description = $"VM is locked by '{config.Lock}'",
                     Context = DiagnosticResultContext.Qemu,
                     SubContext = "Status",
                     Gravity = DiagnosticResultGravity.Warning,
                 });
             }
-            #endregion
 
-            #region Check Virtio
-            //controller SCSI
-            if (vm.Config.ExtensionData.TryGetValue("scsihw", out var scsiHw)
-                && !scsiHw.ToString()!.StartsWith("virtio"))
+            #region Virtio
+            if (config.ExtensionData.TryGetValue("scsihw", out var scsiHw) && !scsiHw.ToString()!.StartsWith("virtio"))
             {
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "WV0001",
                     Description = "For more performance switch controller to VirtIO SCSI",
                     Context = DiagnosticResultContext.Qemu,
                     SubContext = "VirtIO",
                     Gravity = DiagnosticResultGravity.Info,
                 });
-
-                //disks
-                result.AddRange(vm.Config.Disks.Where(a => !a.Id.StartsWith("virtio"))
-                                               .Select(a => new DiagnosticResult
-                                               {
-                                                   Id = errorId,
-                                                   ErrorCode = "WV0001",
-                                                   Description = $"For more performance switch '{a.Id}' hdd to VirtIO",
-                                                   Context = DiagnosticResultContext.Qemu,
-                                                   SubContext = "VirtIO",
-                                                   Gravity = DiagnosticResultGravity.Info,
-                                               }));
+                result.AddRange(config.Disks.Where(a => !a.Id.StartsWith("virtio"))
+                                            .Select(a => new DiagnosticResult
+                                            {
+                                                Id = id,
+                                                ErrorCode = "WV0001",
+                                                Description = $"For more performance switch '{a.Id}' hdd to VirtIO",
+                                                Context = DiagnosticResultContext.Qemu,
+                                                SubContext = "VirtIO",
+                                                Gravity = DiagnosticResultGravity.Info,
+                                            }));
             }
 
-            //network
             for (int i = 0; i < 256; i++)
             {
-                var id = $"net{i}";
-                if (vm.Config.ExtensionData.TryGetValue(id, out var value))
+                var netId = $"net{i}";
+                if (config.ExtensionData.TryGetValue(netId, out var netValue) && !(netValue + "").StartsWith("virtio"))
                 {
-                    var data = value + "";
-                    if (data != null && !data.StartsWith("virtio"))
+                    result.Add(new DiagnosticResult
                     {
-                        result.Add(new DiagnosticResult
-                        {
-                            Id = errorId,
-                            ErrorCode = "WV0001",
-                            Description = $"For more performance switch '{id}' network to VirtIO",
-                            Context = DiagnosticResultContext.Qemu,
-                            SubContext = "VirtIO",
-                            Gravity = DiagnosticResultGravity.Info,
-                        });
-                    }
+                        Id = id,
+                        ErrorCode = "WV0001",
+                        Description = $"For more performance switch '{netId}' network to VirtIO",
+                        Context = DiagnosticResultContext.Qemu,
+                        SubContext = "VirtIO",
+                        Gravity = DiagnosticResultGravity.Info,
+                    });
                 }
             }
             #endregion
 
             #region Unused disk
-            foreach (var unused in vm.Config.ExtensionData.Keys.Where(a => a.StartsWith("unused")))
+            var nodeStorages = await nodeApi.Storage.GetAsync();
+            foreach (var unused in config.ExtensionData.Keys.Where(a => a.StartsWith("unused")))
             {
-                var volume = vm.Config.ExtensionData[unused].ToString()!;
-                var data = volume.Split(":");
-                var storage = node.Storages.FirstOrDefault(a => a.Detail.Storage == data[0]);
-                var size = storage != null
-                            ? FormatHelper.FromBytes(storage.Content.FirstOrDefault(a => a.Volume == volume)!.Size).ToString()
-                            : "";
-
+                var volume = config.ExtensionData[unused].ToString()!;
+                var volumeParts = volume.Split(":");
+                if (volumeParts.Length < 2) { continue; }
+                var storageName = volumeParts[0];
+                var ns = nodeStorages.FirstOrDefault(a => a.Storage == storageName);
+                var size = string.Empty;
+                if (ns != null && ns.Active)
+                {
+                    var contents = await nodeApi.Storage[ns.Storage].Content.GetAsync();
+                    size = FormatHelper.FromBytes(contents.FirstOrDefault(a => a.Volume == volume)?.Size ?? 0).ToString();
+                }
                 result.Add(new DiagnosticResult
                 {
-                    Id = errorId,
+                    Id = id,
                     ErrorCode = "IV0001",
                     Description = $"disk '{unused}' {size} ",
                     Context = DiagnosticResultContext.Qemu,
@@ -792,13 +721,13 @@ public class Application
             #endregion
 
             #region Cdrom
-            foreach (var value in vm.Config.ExtensionData.Values.Where(a => a != null).Select(a => a.ToString()))
+            foreach (var value in config.ExtensionData.Values.Where(a => a != null).Select(a => a.ToString()!))
             {
-                if (value!.Contains("media=cdrom") && value != "none,media=cdrom")
+                if (value.Contains("media=cdrom") && value != "none,media=cdrom")
                 {
                     result.Add(new DiagnosticResult
                     {
-                        Id = errorId,
+                        Id = id,
                         ErrorCode = "WV0002",
                         Description = "Cdrom mounted",
                         Context = DiagnosticResultContext.Qemu,
@@ -809,54 +738,106 @@ public class Application
             }
             #endregion
 
-            CheckCommonVm(info, result, settings.Qemu, vm, DiagnosticResultContext.Qemu, node, errorId);
+            var rrdData = settings.Qemu.TimeSeries switch
+            {
+                SettingsTimeSeriesType.Day => await vmApi.Rrddata.GetAsync(RrdDataTimeFrame.Day, RrdDataConsolidation.Average),
+                SettingsTimeSeriesType.Week => await vmApi.Rrddata.GetAsync(RrdDataTimeFrame.Week, RrdDataConsolidation.Average),
+                _ => throw new NotImplementedException("settings.Qemu.TimeSeries"),
+            };
+
+            await CheckCommonVmAsync(client,
+                                     result,
+                                     settings.Qemu,
+                                     config,
+                                     await vmApi.Pending.GetAsync(),
+                                     await vmApi.Snapshot.GetAsync(),
+                                     rrdData,
+                                     DiagnosticResultContext.Qemu,
+                                     item.Node,
+                                     item.VmId,
+                                     id,
+                                     clusterBackups,
+                                     now);
         }
     }
 
-    private static void CheckCommonVm<TDetail, TConfig>(InfoHelper.Info info,
-                                                        List<DiagnosticResult> result,
-                                                        SettingsThresholdHost thresholdHost,
-                                                        InfoHelper.Info.NodeInfo.VmBaseInfo<TDetail, TConfig> vm,
-                                                        DiagnosticResultContext context,
-                                                        InfoHelper.Info.NodeInfo node,
-                                                        string id)
-        where TDetail : NodeVmBase
-        where TConfig : VmConfig
+    private static async Task CheckLxcAsync(PveClient client,
+                                            List<DiagnosticResult> result,
+                                            List<ClusterResource> resources,
+                                            Settings settings,
+                                            IEnumerable<ClusterBackup> clusterBackups,
+                                            DateTime now)
     {
-        var vmid = vm.Detail.VmId;
+        foreach (var item in resources.Where(a => a.ResourceType == ClusterResourceType.Vm
+                                                  && a.VmType == VmType.Lxc
+                                                  && !a.IsTemplate))
+        {
+            var vmApi = client.Nodes[item.Node].Lxc[item.VmId];
+            var id = item.GetWebUrl();
 
-        #region Vm State
-        result.AddRange(vm.Pending.Where(a => a.Key == "vmstate")
-                                  .Select(a => new DiagnosticResult
-                                  {
-                                      Id = id,
-                                      ErrorCode = "WV0001",
-                                      Description = $"Found vmstate '{a.Value}'",
-                                      Context = DiagnosticResultContext.Qemu,
-                                      SubContext = "VM State",
-                                      Gravity = DiagnosticResultGravity.Critical,
-                                  }));
+            var rrdData = settings.Lxc.TimeSeries switch
+            {
+                SettingsTimeSeriesType.Day => await vmApi.Rrddata.GetAsync(RrdDataTimeFrame.Day, RrdDataConsolidation.Average),
+                SettingsTimeSeriesType.Week => await vmApi.Rrddata.GetAsync(RrdDataTimeFrame.Week, RrdDataConsolidation.Average),
+                _ => throw new NotImplementedException("settings.Lxc.TimeSeries"),
+            };
+
+            await CheckCommonVmAsync(client,
+                                     result,
+                                     settings.Lxc,
+                                     await vmApi.Config.GetAsync(),
+                                     await vmApi.Pending.GetAsync(),
+                                     await vmApi.Snapshot.GetAsync(),
+                                     rrdData,
+                                     DiagnosticResultContext.Lxc,
+                                     item.Node,
+                                     item.VmId,
+                                     id,
+                                     clusterBackups,
+                                     now);
+        }
+    }
+
+    private static async Task CheckCommonVmAsync(PveClient client,
+                                                 List<DiagnosticResult> result,
+                                                 SettingsThresholdHost thresholdHost,
+                                                 VmConfig config,
+                                                 IEnumerable<KeyValue> pending,
+                                                 IEnumerable<VmSnapshot> snapshots,
+                                                 IEnumerable<VmRrdData> rrdData,
+                                                 DiagnosticResultContext context,
+                                                 string node,
+                                                 long vmId,
+                                                 string id,
+                                                 IEnumerable<ClusterBackup> clusterBackups,
+                                                 DateTime now)
+    {
+        #region VM State
+        result.AddRange(pending.Where(a => a.Key == "vmstate")
+                               .Select(a => new DiagnosticResult
+                               {
+                                   Id = id,
+                                   ErrorCode = "WV0001",
+                                   Description = $"Found vmstate '{a.Value}'",
+                                   Context = context,
+                                   SubContext = "VM State",
+                                   Gravity = DiagnosticResultGravity.Critical,
+                               }));
         #endregion
 
-        #region Backup
-        //in all backup
-        var foundBackupConfig = info.Cluster.Backups.Any(a => a.Enabled && a.All);
+        #region Backup config
+        var foundBackupConfig = clusterBackups.Any(a => a.Enabled && a.All);
         if (!foundBackupConfig)
         {
-            foundBackupConfig = info.Cluster.Backups.Where(a => a.Enabled && !string.IsNullOrEmpty(a.VmId))
-                                        .SelectMany(a => a.VmId.Split(","))
-                                        .Any(a => Convert.ToInt64(a) == vmid);
-
-            //in pool
+            foundBackupConfig = clusterBackups.Where(a => a.Enabled && !string.IsNullOrEmpty(a.VmId))
+                                              .SelectMany(a => a.VmId.Split(","))
+                                              .Any(a => long.TryParse(a.Trim(), out var id) && id == vmId);
             if (!foundBackupConfig)
             {
-                foreach (var item in info.Cluster.Backups
-                                                 .Where(a => a.Enabled && !string.IsNullOrWhiteSpace(a.Pool))
-                                                 .Select(a => a.Pool))
+                foreach (var poolId in clusterBackups.Where(a => a.Enabled && !string.IsNullOrWhiteSpace(a.Pool)).Select(a => a.Pool))
                 {
-                    foundBackupConfig = info.Pools.Where(a => a.Id == item)
-                                      .SelectMany(a => a.Detail.Members)
-                                      .Any(a => a.ResourceType == ClusterResourceType.Vm && a.VmId == vmid);
+                    var poolDetail = await client.Pools[poolId].GetAsync();
+                    foundBackupConfig = poolDetail.Members.Any(a => a.ResourceType == ClusterResourceType.Vm && a.VmId == vmId);
                     if (foundBackupConfig) { break; }
                 }
             }
@@ -875,46 +856,44 @@ public class Application
             }
         }
 
-        //check disk no backup
-        result.AddRange(vm.Config.Disks.Where(a => !a.Backup)
-                                       .Select(a => new DiagnosticResult
-                                       {
-                                           Id = id,
-                                           ErrorCode = "WV0001",
-                                           Description = $"Disk '{a.Id}' disabled for backup",
-                                           Context = DiagnosticResultContext.Qemu,
-                                           SubContext = "Backup",
-                                           Gravity = DiagnosticResultGravity.Critical,
-                                       }));
+        result.AddRange(config.Disks.Where(a => !a.Backup)
+                                    .Select(a => new DiagnosticResult
+                                    {
+                                        Id = id,
+                                        ErrorCode = "WV0001",
+                                        Description = $"Disk '{a.Id}' disabled for backup",
+                                        Context = context,
+                                        SubContext = "Backup",
+                                        Gravity = DiagnosticResultGravity.Critical,
+                                    }));
 
-        //check exists backup and recent
-        var dayOld = 60;
-        var foundOldBackup = node.Storages.Where(a => a.Detail.Content.Split(",").Contains("backup"))
-                                          .SelectMany(a => a.Content)
-                                          .Where(a => a.VmId == vmid
-                                                        && a.Content == "backup"
-                                                        && a.CreationDate.Date <= info.Date.Date.AddDays(-dayOld));
-        if (foundOldBackup.Any())
+        // check backup age via storage content
+        var nodeApi = client.Nodes[node];
+        var nodeStorages = await nodeApi.Storage.GetAsync();
+        var backupContents = new List<NodeStorageContent>();
+        foreach (var ns in nodeStorages.Where(a => a.Content != null && a.Content.Split(",").Contains("backup") && a.Active))
+        {
+            var contents = await nodeApi.Storage[ns.Storage].Content.GetAsync();
+            backupContents.AddRange(contents.Where(a => a.VmId == vmId && a.Content == "backup"));
+        }
+
+        const int dayOld = 60;
+        const int dayRecent = 7;
+        var oldBackups = backupContents.Where(a => a.CreationDate.Date <= now.Date.AddDays(-dayOld)).ToList();
+        if (oldBackups.Count > 0)
         {
             result.Add(new DiagnosticResult
             {
                 Id = id,
                 ErrorCode = "CC0001",
-                Description = $"{foundOldBackup.Count()} backup" +
-                              $" {FormatHelper.FromBytes(foundOldBackup.Sum(a => a.Size))} more {dayOld} days are found!",
+                Description = $"{oldBackups.Count} backup {FormatHelper.FromBytes(oldBackups.Sum(a => a.Size))} more {dayOld} days are found!",
                 Context = context,
                 SubContext = "Backup",
                 Gravity = DiagnosticResultGravity.Warning,
             });
         }
 
-        //check exists backup and recent
-        var foundBackup = node.Storages.Where(a => a.Detail.Content.Split(",").Contains("backup"))
-                                       .SelectMany(a => a.Content)
-                                       .Any(a => a.VmId == vmid
-                                                 && a.Content == "backup"
-                                                 && a.CreationDate.Date <= info.Date.Date.AddDays(1));
-        if (!foundBackup)
+        if (!backupContents.Any(a => a.CreationDate.Date >= now.Date.AddDays(-dayRecent)))
         {
             result.Add(new DiagnosticResult
             {
@@ -928,25 +907,16 @@ public class Application
         }
         #endregion
 
-        CheckTaskHistory(result,
-                         node.Tasks.Where(a => a.VmId == vmid.ToString()),
-                         context,
-                         id);
+        #region Task history
+        var dayTask = new DateTimeOffset(now.AddDays(-2)).ToUnixTimeSeconds();
+        var tasks = (await nodeApi.Tasks.GetAsync(errors: true, limit: 1000))
+                    .Where(a => a.StartTime >= dayTask && (a.VmId?.Equals(vmId.ToString()) ?? false));
+        CheckTaskHistory(result, tasks, context, id);
+        #endregion
 
-        CheckSnapshots(result, vm.Snapshots, info.Date, id, context);
+        CheckSnapshots(result, snapshots, now, id, context);
 
-        var rrdData = thresholdHost.TimeSeries switch
-        {
-            SettingsTimeSeriesType.Day => vm.RrdData.Day,
-            SettingsTimeSeriesType.Week => vm.RrdData.Week,
-            _ => throw new NotImplementedException("thresholdHost.TimeSeries"),
-        };
-
-        CheckThresholdHost(result,
-                           thresholdHost,
-                           context,
-                           id,
-                           rrdData.Select(a => ((IMemory)a, (INetIO)a, (ICpu)a)));
+        CheckThresholdHost(result, thresholdHost, context, id, rrdData.Select(a => new ThresholdRddData(a, a, a)));
     }
 
     private static void CheckTaskHistory(List<DiagnosticResult> result,
@@ -969,175 +939,6 @@ public class Application
         }
     }
 
-    private static void CheckThresholdHost(List<DiagnosticResult> result,
-                                           SettingsThresholdHost thresholdHost,
-                                           DiagnosticResultContext context,
-                                           string id,
-                                           IEnumerable<(IMemory Memory, INetIO NetIO, ICpu Cpu)> rrdData)
-    {
-        CheckThreshold(result,
-                       thresholdHost.Cpu,
-                       "WV0002",
-                       context,
-                       "Usage",
-                       [(rrdData.Average(a => a.Cpu.CpuUsagePercentage) * 100,
-                         0d,
-                         id,
-                         $"CPU (rrd {thresholdHost.TimeSeries} AVERAGE)")],
-                       true,
-                       false);
-
-        CheckThreshold(result,
-                       thresholdHost.Memory,
-                       "WV0002",
-                       context,
-                       "Usage",
-                       [(rrdData.Average(a => Convert.ToDouble(a.Memory.MemoryUsage)),
-                         rrdData.Average(a => Convert.ToDouble(a.Memory.MemorySize)),
-                         id,
-                         $"Memory (rrd {thresholdHost.TimeSeries} AVERAGE)") ],
-                       false,
-                       true);
-
-        CheckThreshold(result,
-                       thresholdHost.Network,
-                        "WV0002",
-                        context,
-                        "Usage",
-                        [(rrdData.Average(a => a.NetIO.NetIn),
-                          0d,
-                          id,
-                          $"NetIn (rrd {thresholdHost.TimeSeries} AVERAGE)") ],
-                        true,
-                        false);
-
-        CheckThreshold(result,
-                       thresholdHost.Network,
-                       "WV0002",
-                       context,
-                       "Usage",
-                       [(rrdData.Average(a => a.NetIO.NetOut),
-                         0d,
-                         id,
-                         $"NetIn (rrd {thresholdHost.TimeSeries} AVERAGE)") ],
-                       true,
-                       false);
-    }
-
-    private static void CheckNodeRrd(List<DiagnosticResult> result,
-                                     Settings settings,
-                                     string id,
-                                     IEnumerable<NodeRrdData> rrdData)
-    {
-        CheckThresholdHost(result,
-                           settings.Node,
-                           DiagnosticResultContext.Node,
-                           id,
-                           rrdData.Select(a => ((IMemory)a, (INetIO)a, (ICpu)a)));
-
-        CheckThreshold(result,
-                       settings.Node.Cpu,
-                       "WV0002",
-                       DiagnosticResultContext.Node,
-                       "Usage",
-                       [(rrdData.Average(a => a.IoWait) * 100,
-                         0d,
-                         id,
-                         $"IOWait (rrd {settings.Node.TimeSeries} AVERAGE)") ],
-                       true,
-                       false);
-
-        CheckThreshold(result,
-                       settings.Storage.Threshold,
-                       "WV0002",
-                       DiagnosticResultContext.Node,
-                       "Usage",
-                       [(rrdData.Average(a => a.RootUsage),
-                         rrdData.Average(a => a.RootSize),
-                         id,
-                         $"Root space (rrd {settings.Node.TimeSeries} AVERAGE)") ],
-                       false,
-                       true);
-
-        CheckThreshold(result,
-                       settings.Storage.Threshold,
-                       "WV0002",
-                       DiagnosticResultContext.Node,
-                       "Usage",
-                       [(rrdData.Average(a => a.SwapUsage),
-                         rrdData.Average(a =>  Convert.ToDouble(a.SwapSize)) ,
-                         id,
-                         $"SWAP (rrd {settings.Node.TimeSeries} AVERAGE)") ],
-                       false,
-                       true);
-    }
-
-    private static void CheckThreshold(List<DiagnosticResult> result,
-                                       SettingsThreshold<double> threshold,
-                                       string errorCode,
-                                       DiagnosticResultContext context,
-                                       string subContext,
-                                       IEnumerable<(double Usage, double Size, string Id, string PrefixDescription)> data,
-                                       bool isValue,
-                                       bool formatByte)
-    {
-        if (threshold.Warning == 0 || threshold.Critical == 0) { return; }
-
-        var ranges = new[] { threshold.Warning, threshold.Critical, threshold.Critical * 100 };
-        var gravity = new[] { DiagnosticResultGravity.Warning, DiagnosticResultGravity.Critical };
-
-        for (int i = 0; i < 3; i++)
-        {
-            double GetValue(double usage, double size) => Math.Round(isValue ? usage : usage / size * 100.0, 1);
-
-            string MakeDescription(string PrefixDescription, double usage, double size)
-            {
-                var txt = $"{PrefixDescription} usage {GetValue(usage, size)}%";
-                if (formatByte) { txt += $" - {FormatHelper.FromBytes(usage)} of {FormatHelper.FromBytes(size)}"; }
-                return txt;
-            }
-
-            result.AddRange(data.Where(a => GetValue(a.Usage, a.Size) >= ranges[i]
-                                            && GetValue(a.Usage, a.Size) <= ranges[i + 1])
-                                .Select(a => new DiagnosticResult
-                                {
-                                    Id = a.Id,
-                                    ErrorCode = errorCode,
-                                    Description = MakeDescription(a.PrefixDescription, a.Usage, a.Size),
-                                    Context = context,
-                                    SubContext = subContext,
-                                    Gravity = gravity[i],
-                                }));
-        }
-    }
-
-    // private static void CheckThreshold(List<DiagnosticResult> result,
-    //                                     SettingsThreshold<double> threshold,
-    //                                     string errorCode,
-    //                                     DiagnosticResultContext context,
-    //                                     string subContext,
-    //                                     IEnumerable<(double Usage, string Id, string PrefixDescription)> data)
-    // {
-    //     if (threshold.Warning == 0 || threshold.Critical == 0) { return; }
-
-    //     var ranges = new[] { threshold.Warning, threshold.Critical, threshold.Critical * 100 };
-    //     var gravity = new[] { DiagnosticResultGravity.Warning, DiagnosticResultGravity.Critical };
-
-    //     for (int i = 0; i < 3; i++)
-    //     {
-    //         result.AddRange(data.Where(a => a.Usage >= ranges[i] && a.Usage <= ranges[i + 1])
-    //                             .Select(a => new DiagnosticResult
-    //                             {
-    //                                 Id = a.Id,
-    //                                 ErrorCode = errorCode,
-    //                                 Description = $"{a.PrefixDescription} usage {Math.Round(a.Usage, 1)}%",
-    //                                 Context = context,
-    //                                 SubContext = subContext,
-    //                                 Gravity = gravity[i],
-    //                             }));
-    //     }
-    // }
-
     private static void CheckSnapshots(List<DiagnosticResult> result,
                                        IEnumerable<VmSnapshot> snapshots,
                                        DateTime execution,
@@ -1147,7 +948,6 @@ public class Application
         const string autosnapAppName = "cv4pve-autosnap";
         const string autosnapAppNameOld = "eve4pve-autosnap";
 
-        //autosnap
         if (!snapshots.Any(a => a.Description == autosnapAppName || a.Description == $"{autosnapAppName}\n"))
         {
             result.Add(new DiagnosticResult
@@ -1161,7 +961,6 @@ public class Application
             });
         }
 
-        //old autosnap
         if (snapshots.Any(a => a.Description == autosnapAppNameOld || a.Description == $"{autosnapAppNameOld}\n"))
         {
             result.Add(new DiagnosticResult
@@ -1175,7 +974,6 @@ public class Application
             });
         }
 
-        //old month
         var snapOldCount = snapshots.Count(a => a.Name != "current" && a.Date < execution.AddMonths(-1));
         if (snapOldCount > 0)
         {
@@ -1188,6 +986,153 @@ public class Application
                 SubContext = "SnapshotOld",
                 Gravity = DiagnosticResultGravity.Warning,
             });
+        }
+    }
+
+    private record ThresholdRddData(IMemory Memory, INetIO NetIO, ICpu Cpu);
+
+    private static void CheckThresholdHost(List<DiagnosticResult> result,
+                                           SettingsThresholdHost thresholdHost,
+                                           DiagnosticResultContext context,
+                                           string id,
+                                           IEnumerable<ThresholdRddData> rrdData)
+    {
+        CheckThreshold(result,
+                       thresholdHost.Cpu,
+                       "WV0002",
+                       context,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.Cpu.CpuUsagePercentage) * 100,
+                                               0d,
+                                               id,
+                                               $"CPU (rrd {thresholdHost.TimeSeries} AVERAGE)")],
+                       true,
+                       false);
+
+        CheckThreshold(result,
+                       thresholdHost.Memory,
+                       "WV0002",
+                       context,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => Convert.ToDouble(a.Memory.MemoryUsage)),
+                                               rrdData.Average(a => Convert.ToDouble(a.Memory.MemorySize)),
+                                               id,
+                                               $"Memory (rrd {thresholdHost.TimeSeries} AVERAGE)")],
+                       false,
+                       true);
+
+        CheckThreshold(result,
+                       thresholdHost.Network,
+                       "WV0002",
+                       context,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.NetIO.NetIn),
+                                               0d,
+                                               id,
+                                               $"NetIn (rrd {thresholdHost.TimeSeries} AVERAGE)")],
+                       true,
+                       false);
+
+        CheckThreshold(result,
+                       thresholdHost.Network,
+                       "WV0002",
+                       context,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.NetIO.NetOut),
+                                               0d,
+                                               id,
+                                               $"NetOut (rrd {thresholdHost.TimeSeries} AVERAGE)")],
+                       true,
+                       false);
+    }
+
+    private static void CheckNodeRrd(List<DiagnosticResult> result,
+                                     Settings settings,
+                                     string id,
+                                     IEnumerable<NodeRrdData> rrdData)
+    {
+        CheckThresholdHost(result,
+                           settings.Node,
+                           DiagnosticResultContext.Node,
+                           id,
+                           rrdData.Select(a => new ThresholdRddData(a, a, a)));
+
+        CheckThreshold(result,
+                       settings.Node.Cpu,
+                       "WV0002",
+                       DiagnosticResultContext.Node,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.IoWait) * 100,
+                                               0d,
+                                               id,
+                                               $"IOWait (rrd {settings.Node.TimeSeries} AVERAGE)")],
+                       true,
+                       false);
+
+        CheckThreshold(result,
+                       settings.Storage.Threshold,
+                       "WV0002",
+                       DiagnosticResultContext.Node,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.RootUsage),
+                                               rrdData.Average(a => a.RootSize),
+                                               id,
+                                               $"Root space (rrd {settings.Node.TimeSeries} AVERAGE)")],
+                       false,
+                       true);
+
+        CheckThreshold(result,
+                       settings.Storage.Threshold,
+                       "WV0002",
+                       DiagnosticResultContext.Node,
+                       "Usage",
+                       [new ThresholdDataPoint(rrdData.Average(a => a.SwapUsage),
+                                               rrdData.Average(a => Convert.ToDouble(a.SwapSize)),
+                                               id,
+                                               $"SWAP (rrd {settings.Node.TimeSeries} AVERAGE)")],
+                       false,
+                       true);
+    }
+
+    private record ThresholdDataPoint(double Usage, double Size, string Id, string PrefixDescription);
+
+
+    private static void CheckThreshold(List<DiagnosticResult> result,
+                                       SettingsThreshold<double> threshold,
+                                       string errorCode,
+                                       DiagnosticResultContext context,
+                                       string subContext,
+                                       IEnumerable<ThresholdDataPoint> data,
+                                       bool isValue,
+                                       bool formatByte)
+    {
+        if (threshold.Warning == 0 || threshold.Critical == 0) { return; }
+
+        var ranges = new[] { threshold.Warning, threshold.Critical, threshold.Critical * 100 };
+        var gravity = new[] { DiagnosticResultGravity.Warning, DiagnosticResultGravity.Critical };
+
+        for (int i = 0; i < 2; i++)
+        {
+            double GetValue(double usage, double size) => Math.Round(isValue ? usage : usage / size * 100.0, 1);
+
+            string MakeDescription(string prefix, double usage, double size)
+            {
+                var txt = $"{prefix} usage {GetValue(usage, size)}%";
+                if (formatByte) { txt += $" - {FormatHelper.FromBytes(usage)} of {FormatHelper.FromBytes(size)}"; }
+                return txt;
+            }
+
+            result.AddRange(data.Where(a => GetValue(a.Usage, a.Size) >= ranges[i] 
+                                            && GetValue(a.Usage, a.Size) < ranges[i + 1])
+                                .Select(a => new DiagnosticResult
+                                {
+                                    Id = a.Id,
+                                    ErrorCode = errorCode,
+                                    Description = MakeDescription(a.PrefixDescription, a.Usage, a.Size),
+                                    Context = context,
+                                    SubContext = subContext,
+                                    Gravity = gravity[i],
+                                }));
         }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Application.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Application.cs
@@ -1122,7 +1122,7 @@ public class Application
                 return txt;
             }
 
-            result.AddRange(data.Where(a => GetValue(a.Usage, a.Size) >= ranges[i] 
+            result.AddRange(data.Where(a => GetValue(a.Usage, a.Size) >= ranges[i]
                                             && GetValue(a.Usage, a.Size) < ranges[i + 1])
                                 .Select(a => new DiagnosticResult
                                 {

--- a/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
@@ -5,7 +5,6 @@
 
 using System.Text.Json;
 using Corsinvest.ProxmoxVE.Api.Console.Helpers;
-using Corsinvest.ProxmoxVE.Api.Extension.Utils;
 using Corsinvest.ProxmoxVE.Api.Shared.Utils;
 using Corsinvest.ProxmoxVE.Diagnostic.Api;
 using Microsoft.Extensions.Logging;
@@ -43,67 +42,33 @@ app.AddCommand("create-ignored-issues", $"Create File ignored issues ({ignoredIs
        Console.Out.WriteLine($"Create file: {ignoredIssuesFileName}");
    });
 
-async Task<InfoHelper.Info> GetInfo()
-    => await InfoHelper.CollectAsync(await app.ClientTryLoginAsync(loggerFactory), true, 2, false, false);
-
-var fileExport = "data.json";
-app.AddCommand("export-collect", $"Export collect data collect to {fileExport}")
+app.AddCommand("execute", "Execute diagnostic and print result to console")
    .SetAction(async (action) =>
    {
-       File.WriteAllText(fileExport, JsonSerializer.Serialize(await GetInfo(), new JsonSerializerOptions { WriteIndented = true }));
-       Console.Out.WriteLine($"Exported {fileExport}!");
-   });
+       var client = await app.ClientTryLoginAsync(loggerFactory);
 
-var cmdExamineCollect = app.AddCommand("examine-collect", $"Examine collect data collect from {fileExport}");
-cmdExamineCollect.Hidden = true;
-cmdExamineCollect.SetAction((action) =>
-{
-    var info = JsonSerializer.Deserialize<InfoHelper.Info>(File.ReadAllText(fileExport))!;
-    Print(info,
-          action.GetValue(optSettingsFile)!,
-          action.GetValue(optIgnoredIssuesFile)!,
-          action.GetValue(optShowIgnoredIssues),
-          action.GetValue(optOutput));
-});
+       var settings = !string.IsNullOrWhiteSpace(action.GetValue(optSettingsFile))
+                           ? JsonSerializer.Deserialize<Settings>(File.ReadAllText(action.GetValue(optSettingsFile)!))
+                           : new Settings();
 
-app.AddCommand("execute", $"Execute diagnostic and print result to console")
-   .SetAction(async (action) =>
-   {
-       Print(await GetInfo(),
-             action.GetValue(optSettingsFile)!,
-             action.GetValue(optIgnoredIssuesFile)!,
-             action.GetValue(optShowIgnoredIssues)!,
-             action.GetValue(optOutput));
+       var ignoredIssues = !string.IsNullOrWhiteSpace(action.GetValue(optIgnoredIssuesFile))
+                               ? JsonSerializer.Deserialize<List<DiagnosticResult>>(File.ReadAllText(action.GetValue(optIgnoredIssuesFile)!))
+                               : [];
+
+       var result = await Application.AnalyzeAsync(client, settings!, ignoredIssues!);
+
+       PrintResult([.. result.Where(a => !a.IsIgnoredIssue)], action.GetValue(optOutput));
+       if (action.GetValue(optShowIgnoredIssues)) { PrintResult([.. result.Where(a => a.IsIgnoredIssue)], action.GetValue(optOutput)); }
    });
 
 return await app.ExecuteAppAsync(args, loggerFactory.CreateLogger(typeof(Program)));
-
-void Print(InfoHelper.Info info,
-           string settingsFile,
-           string ignoredIssuesFile,
-           bool showIgnoredIssues,
-           TableGenerator.Output output)
-{
-    var settings = !string.IsNullOrWhiteSpace(settingsFile)
-                        ? JsonSerializer.Deserialize<Settings>(File.ReadAllText(settingsFile))
-                        : new Settings();
-
-    var ignoredIssues = !string.IsNullOrWhiteSpace(ignoredIssuesFile)
-                            ? JsonSerializer.Deserialize<List<DiagnosticResult>>(File.ReadAllText(ignoredIssuesFile))
-                            : [];
-
-    var result = Application.Analyze(info, settings!, ignoredIssues!);
-
-    PrintResult([.. result.Where(a => !a.IsIgnoredIssue)], output);
-    if (showIgnoredIssues) { PrintResult([.. result.Where(a => a.IsIgnoredIssue)], output); }
-}
 
 void PrintResult(ICollection<DiagnosticResult> data, TableGenerator.Output output)
 {
     var rows = data.OrderByDescending(a => a.Gravity)
                    .ThenBy(a => a.Context)
                    .ThenBy(a => a.SubContext)
-                   .Select(a => new object[] { a.Id, a.Description, a.Context, a.SubContext, a.Gravity });
+                   .Select(a => new object[] { a.Id, a.Description, a.Context, a.SubContext, a.Gravity});
 
     Console.Out.Write(TableGenerator.To(["Id", "Description", "Context", "SubContext", "Gravity"], rows, output));
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
@@ -68,7 +68,7 @@ void PrintResult(ICollection<DiagnosticResult> data, TableGenerator.Output outpu
     var rows = data.OrderByDescending(a => a.Gravity)
                    .ThenBy(a => a.Context)
                    .ThenBy(a => a.SubContext)
-                   .Select(a => new object[] { a.Id, a.Description, a.Context, a.SubContext, a.Gravity});
+                   .Select(a => new object[] { a.Id, a.Description, a.Context, a.SubContext, a.Gravity });
 
     Console.Out.Write(TableGenerator.To(["Id", "Description", "Context", "SubContext", "Gravity"], rows, output));
 }


### PR DESCRIPTION
## Summary

- **Breaking change**: `Analyze(InfoHelper.Info)` replaced by `AnalyzeAsync(PveClient)` — the diagnostic engine now queries the PVE API directly instead of relying on a pre-collected snapshot
- Removed `InfoHelper` dependency entirely (`export-collect` / `examine-collect` commands removed)
- All check methods converted to `async` (`CheckStorageAsync`, `CheckNodesAsync`, `CheckQemuAsync`, `CheckLxcAsync`)
- Version bumped to `1.10.0`, dependencies updated to `9.1.5`

## Bug fixes included

- Add `DiagnosticResult` when QEMU guest agent is not running (was silently swallowed)
- Fix backup age check: `dayOld=60`, `dayRecent=7` (previous condition `<= tomorrow` was always true)
- Safe integer parsing with `int.TryParse` / `long.TryParse` instead of `int.Parse` / `Convert.ToInt64`
- Use `TryGetValue` on `nodeCompareData` dictionary to avoid `KeyNotFoundException`
- Guard against `volume.Split(":").Length < 2` before accessing index
- Null-safe `VmId` comparison with `?.Equals()`

## Test plan

- [ ] Build succeeds
- [ ] `execute` command connects to a PVE cluster and returns diagnostic results
- [ ] Ignored issues filtering works correctly
- [ ] Output formats (table, JSON, CSV) render correctly