### PR TITLE
feat: v2.2.0 — CVE scanning, full parallelisation, README fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,5 +333,4 @@ ASALocalRun/
 
 artifacts_nupkg/
 
-.claude
-.vscode
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ---
 
+## [2.2.0] — 2026-04-13
+
+### New checks
+
+**Node — CVE scanning (opt-in):**
+- **Open CVEs on installed packages** (`CN0014` / `WN0041`) — checks every installed package against the Debian security advisory feed for the detected PVE release. Packages with known open vulnerabilities are reported as Critical (high severity) or Warning (medium / unrated).
+- **Proxmox-specific CVEs** (`CN0015` / `WN0042`) — checks the NVD database for CVEs affecting Proxmox VE. Only CVEs that apply to the installed version are reported. Severity ≥ 9.0 → Critical; ≥ 7.0 → Warning.
+
+Both checks are **disabled by default**. Enable them via the new `Cve` settings section.
+
+### Settings
+
+New `Cve` section:
+
+```json
+{
+  "Cve": {
+    "DebianTrackerEnabled": false,
+    "NvdEnabled": false,
+    "MinCvssScore": 7.0
+  }
+}
+```
+
+- `DebianTrackerEnabled` — check installed packages against Debian security advisories.
+- `NvdEnabled` — check for CVEs specific to Proxmox VE.
+- `MinCvssScore` — ignore CVEs below this severity score (default: 7.0).
+
+The correct Debian release is detected automatically from the PVE version — no manual configuration needed.
+
+### Performance
+
+Analysis is faster on large clusters. All per-node API calls (subscription, services, certificates, replication, APT, disks, ZFS, tasks, etc.) are now fetched in parallel instead of sequentially. Cluster-level calls (HA, firewall, backup, users) are also parallelised. On a typical cluster this further reduces analysis time compared to v2.1.0.
+
+---
+
 ## [2.1.0] — 2026-04-08
 
 ### New checks

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.2.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <PackageOutputPath>..\nupkgs\</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.11" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.11" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.13" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -195,19 +195,26 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | Health score low                   | WG0032        | HealthScore      | Warning/Critical | Composite health score below threshold                                         |
 | Task history errors                | CN0005        | Tasks            | Critical         | Failed tasks found in the last 48 hours                                        |
 | Disk SMART problem                 | WN0016        | S.M.A.R.T.       | Warning          | Disk reports a SMART health problem                                            |
-| Disk temperature                   | WN0018/CN0006 | S.M.A.R.T.       | Warning/Critical | Disk temperature exceeds configured threshold                                  |
+| Disk temperature                   | WN0019/CN0007 | S.M.A.R.T.       | Warning/Critical | Disk temperature exceeds configured threshold                                  |
 | Disk reallocated sectors           | WN0020        | S.M.A.R.T.       | Warning          | Disk has reallocated sectors — disk may be failing                             |
 | Disk pending sectors               | CN0008        | S.M.A.R.T.       | Critical         | Disk has pending sectors — imminent data loss risk                             |
 | Disk uncorrectable sectors         | CN0009        | S.M.A.R.T.       | Critical         | Disk has offline uncorrectable sectors                                         |
 | Disk UDMA CRC errors               | WN0021        | S.M.A.R.T.       | Warning          | Disk has UDMA CRC errors — check cable/controller                              |
 | Disk reported uncorrectable errors | WN0022        | S.M.A.R.T.       | Warning          | Disk has reported uncorrectable errors                                         |
 | SSD wearout not valid              | WN0017        | SSD Wearout      | Warning          | SSD does not expose wear data                                                  |
-| SSD wearout above threshold        | WN0023/CN0007 | SSD Wearout      | Warning/Critical | SSD wearout consumed above threshold                                           |
+| SSD wearout above threshold        | WN0018        | SSD Wearout      | Warning/Critical | SSD wearout consumed above threshold                                           |
+| ZFS pool usage above threshold     | WN0023        | Zfs              | Warning/Critical | ZFS pool disk usage above configured threshold                                 |
 | ZFS pool health problem            | CN0010        | Zfs              | Critical         | ZFS pool is not in ONLINE state                                                |
 | ZFS vdev degraded/faulted          | CN0012        | Zfs              | Critical         | ZFS pool vdev is in a degraded or faulted state                                |
 | ZFS vdev I/O errors                | WN0025        | Zfs              | Warning          | ZFS pool vdev has accumulated read/write/checksum errors                       |
 | ZFS pool errors                    | WN0024        | Zfs              | Warning          | ZFS pool reports errors                                                        |
-| LVM-thin metadata usage            | WN0026/CN0011 | Storage          | Warning/Critical | LVM-thin metadata usage is high — full metadata causes data corruption         |
+| LVM-thin metadata usage            | WN0026/CN0013 | LvmThin          | Warning/Critical | LVM-thin metadata usage is high — full metadata causes data corruption         |
+| IOWait above threshold             | WN0028        | Usage            | Warning/Critical | CPU IOWait above configured threshold — indicates storage bottleneck           |
+| Root filesystem usage              | WN0029        | Usage            | Warning/Critical | Node root filesystem usage above configured threshold                          |
+| SWAP usage above threshold         | WN0030        | Usage            | Warning/Critical | Node SWAP usage above configured threshold — indicates RAM pressure             |
+| Unknown resource type              | CU0001        | Status           | Critical         | A cluster resource with an unknown type was detected                           |
+| Open CVE on installed package      | WN0041/CN0014 | CVE              | Warning/Critical | Installed package has an open CVE in the Debian security tracker               |
+| Proxmox VE CVE                     | WN0042/CN0015 | CVE              | Warning/Critical | A known CVE affects the installed Proxmox VE version                           |
 
 </details>
 
@@ -421,6 +428,13 @@ cv4pve-diag --host=pve.local --api-token=user@realm!token=uuid --settings-file=s
     "MaxAgeDays": 60, // warn if backup older than N days, 0 = disabled
     "RecentDays": 7, // warn if no backup in last N days, 0 = disabled
   },
+  "MaxParallelRequests": 5, // global parallel API requests (1 = sequential)
+  "ApiTimeout": 0,          // HTTP timeout in seconds (0 = 100s default)
+  "Cve": {
+    "DebianTrackerEnabled": false, // check installed packages against Debian security advisories
+    "NvdEnabled": false,           // check for CVEs specific to Proxmox VE (NVD API 2.0)
+    "MinCvssScore": 7.0,           // ignore CVEs below this CVSS score (NVD only)
+  },
 }
 ```
 
@@ -436,6 +450,78 @@ Set `Warning` and `Critical` to `0` to disable health score checks entirely.
 > **PSI Pressure** (PVE 9.0+): Linux Pressure Stall Information metrics. Checks are automatically skipped on older PVE versions where the values are always zero.
 
 </details>
+
+---
+
+## Performance Tuning
+
+By default the diagnostic runs up to **5 parallel API requests** (`MaxParallelRequests = 5`). This works well for most clusters, but you can tune it to match your environment.
+
+### Speed up the diagnostic
+
+Increase `MaxParallelRequests` to fetch more data at the same time:
+
+```jsonc
+"MaxParallelRequests": 10
+```
+
+> **Don't go too high.** Each parallel request is a real HTTP call to Proxmox. Too many at once can slow down the API, increase memory usage on both sides, and make the diagnostic less stable. Values between 5 and 15 are a reasonable range.
+
+### Handle slow or high-latency clusters
+
+Parallelism means more simultaneous requests — if your cluster is slow or the network has high latency, some calls may time out. Increase `ApiTimeout` to give them more time:
+
+```jsonc
+"ApiTimeout": 300   // seconds (0 = 100s default)
+```
+
+### Summary
+
+| Setting | Effect | Default |
+|---------|--------|---------|
+| `MaxParallelRequests` ↑ | Faster, but more load on Proxmox and higher memory usage | 5 |
+| `ApiTimeout` ↑ | Avoids timeouts on slow/high-latency clusters | 100s |
+
+---
+
+## CVE Scanning
+
+cv4pve-diag can optionally check your cluster for known security vulnerabilities. Both sources are **disabled by default** and require internet access at runtime.
+
+### Debian Security Tracker
+
+Checks every installed package on each node against the Debian security advisory feed, automatically filtered to the Debian release that matches your PVE version (e.g. bookworm for PVE 8, bullseye for PVE 7).
+
+```jsonc
+"Cve": {
+  "DebianTrackerEnabled": true
+}
+```
+
+- Packages with open, high-severity vulnerabilities → **Critical** (`CN0014`)
+- Packages with open, medium or unrated vulnerabilities → **Warning** (`WN0041`)
+
+### NVD (Proxmox VE CVEs)
+
+Queries the NVD database for CVEs that specifically affect Proxmox VE. Only CVEs that apply to your installed version are reported. Requires no API key.
+
+```jsonc
+"Cve": {
+  "NvdEnabled": true,
+  "MinCvssScore": 7.0   // ignore CVEs below this score
+}
+```
+
+- CVSS score ≥ 9.0 → **Critical** (`CN0015`)
+- CVSS score ≥ 7.0 → **Warning** (`WN0042`)
+
+### Summary
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Cve.DebianTrackerEnabled` | Check installed packages against Debian advisories | `false` |
+| `Cve.NvdEnabled` | Check for Proxmox VE CVEs via NVD | `false` |
+| `Cve.MinCvssScore` | Minimum CVSS score to report (NVD only) | `7.0` |
 
 ---
 

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
@@ -12,9 +12,12 @@ public partial class DiagnosticEngine
 {
     private async Task<bool> CheckClusterAsync()
     {
-        var clusterConfigNodes = await client.Cluster.Config.Nodes.GetAsync();
+        var clusterConfigNodesTask = client.Cluster.Config.Nodes.GetAsync();
+        var clusterBackupTask = client.Cluster.Backup.GetAsync();
+        await Task.WhenAll(clusterConfigNodesTask, clusterBackupTask);
+        var clusterConfigNodes = clusterConfigNodesTask.Result;
         var hasCluster = clusterConfigNodes.Any();
-        _clusterBackups = await client.Cluster.Backup.GetAsync();
+        _clusterBackups = clusterBackupTask.Result;
 
         CheckClusterBackupCompression();
 
@@ -65,8 +68,8 @@ public partial class DiagnosticEngine
 
         // Backup jobs without retention policy — storage will fill up indefinitely
         _result.AddRange(backupList.Where(a => a.Enabled
-                                               && a.ExtensionData?.ContainsKey("maxfiles") != true
-                                               && a.ExtensionData?.ContainsKey("prune-backups") != true)
+                                               && a.ExtensionData?.ContainsKey("maxfiles") is not true
+                                               && a.ExtensionData?.ContainsKey("prune-backups") is not true)
                                    .Select(a => new DiagnosticResult
                                    {
                                        Id = $"cluster/backup/{a.Id}",
@@ -81,8 +84,11 @@ public partial class DiagnosticEngine
     private async Task CheckClusterHaAndReplicationAsync()
     {
         // Cluster without any HA resource configured — no automatic failover on node failure
-        var haResources = await client.Cluster.Ha.Resources.GetAsync();
-        if (!haResources.Any())
+        var haResourcesTask = client.Cluster.Ha.Resources.GetAsync();
+        var replJobsTask = client.Cluster.Replication.GetAsync();
+        await Task.WhenAll(haResourcesTask, replJobsTask);
+
+        if (!haResourcesTask.Result.Any())
         {
             _result.Add(new DiagnosticResult
             {
@@ -96,8 +102,7 @@ public partial class DiagnosticEngine
         }
 
         // Cluster without any replication job — no storage redundancy between nodes
-        var replJobs = await client.Cluster.Replication.GetAsync();
-        if (!replJobs.Any())
+        if (!replJobsTask.Result.Any())
         {
             _result.Add(new DiagnosticResult
             {
@@ -227,9 +232,10 @@ public partial class DiagnosticEngine
         }
 
         // Firewall enabled at cluster level but disabled on individual nodes — inconsistent protection
-        foreach (var node in _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline))
+        var onlineNodes = _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline).ToList();
+        var nodeFwResults = await RunParallelAsync(onlineNodes, node => client.Nodes[node.Node].Firewall.Options.GetAsync());
+        foreach (var (node, nodeFwOptions) in onlineNodes.Zip(nodeFwResults))
         {
-            var nodeFwOptions = await client.Nodes[node.Node].Firewall.Options.GetAsync();
             if (!nodeFwOptions.Enable)
             {
                 _result.Add(new DiagnosticResult
@@ -262,11 +268,15 @@ public partial class DiagnosticEngine
     private async Task CheckClusterAccessAsync()
     {
         // Local users (pam/pve realm) without expiration and tokens without expiration are a security risk
-        var accessUsers = await client.Access.Users.GetAsync();
+        var accessUsersTask = client.Access.Users.GetAsync();
+        var tfaEntriesTask = client.Access.Tfa.GetAsync();
+        var aclsTask = client.Access.Acl.GetAsync();
+        await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask);
+        var accessUsers = accessUsersTask.Result;
+        var tfaEntries = tfaEntriesTask.Result;
+        var acls = aclsTask.Result;
 
-        // TFA check — fetch once and reuse for all user checks
-        var tfaEntries = await client.Access.Tfa.GetAsync();
-        var usersWithTfa = tfaEntries.Where(t => t.Entries?.Any() == true)
+        var usersWithTfa = tfaEntries.Where(t => t.Entries?.Any() is true)
                                      .Select(t => t.UserId)
                                      .ToHashSet();
 
@@ -286,7 +296,6 @@ public partial class DiagnosticEngine
         }
 
         // Admin users without TFA — fetch ACLs once to find users with Administrator role
-        var acls = await client.Access.Acl.GetAsync();
         var adminUserIds = acls.Where(a => a.Roleid == "Administrator" && a.Type == "user")
                                .Select(a => a.UsersGroupid)
                                .ToHashSet();

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
@@ -43,9 +43,8 @@ public partial class DiagnosticEngine
         #region Pending config changes
         // Config changes applied via the API are held in "pending" until the VM is rebooted.
         // Calling out pending changes helps operators know a reboot is needed for changes to take effect.
-        var pendingAll = pending.ToList();
-        var pendingChanges = pendingAll.Where(a => a.Key != "vmstate"
-                                                   && (a.Pending != null || a.Delete == 1)).ToList();
+        var pendingChanges = pending.Where(a => a.Key != "vmstate"
+                                                && (a.Pending != null || a.Delete == 1)).ToList();
         if (pendingChanges.Count > 0)
         {
             _result.Add(new DiagnosticResult
@@ -112,8 +111,8 @@ public partial class DiagnosticEngine
         if (!foundBackupConfig)
         {
             foundBackupConfig = _clusterBackups.Where(a => a.Enabled && !string.IsNullOrEmpty(a.VmId))
-                                              .SelectMany(a => a.VmId.Split(","))
-                                              .Any(a => long.TryParse(a.Trim(), out var id) && id == vmId);
+                                               .SelectMany(a => a.VmId.Split(","))
+                                               .Any(a => long.TryParse(a.Trim(), out var id) && id == vmId);
             if (!foundBackupConfig)
             {
                 foreach (var poolId in _clusterBackups.Where(a => a.Enabled && !string.IsNullOrWhiteSpace(a.Pool)).Select(a => a.Pool))
@@ -158,7 +157,7 @@ public partial class DiagnosticEngine
                                      {
                                          Id = id,
                                          ErrorCode = "WG0018",
-                                         Description = $"Unused disk '{a.Id}'{(a.SizeBytes > 0 ? $" ({FormatHelper.FromBytes(a.SizeBytes)})" : string.Empty)} — detached from VM but still in storage",
+                                         Description = $"Unused disk '{a.Id}'{(a.SizeBytes > 0 ? $" ({FormatHelper.FromBytes(a.SizeBytes)})" : "")} — detached from VM but still in storage",
                                          Context = context,
                                          SubContext = "Hardware",
                                          Gravity = DiagnosticResultGravity.Warning,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
@@ -5,24 +5,45 @@
 
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Common;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 
 namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 
 public partial class DiagnosticEngine
 {
-    private async Task CheckLxcAsync()
+    private record ContainerFetchData(ClusterResource Item,
+                                      VmConfigLxc Config,
+                                      VmFirewallOptions Firewall,
+                                      IEnumerable<KeyValue> Pending,
+                                      IEnumerable<VmSnapshot> Snapshots);
+
+    private async Task<ContainerFetchData> FetchContainerDataAsync(ClusterResource item)
     {
-        foreach (var item in _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
-                                                  && a.VmType == VmType.Lxc
-                                                  && !a.IsTemplate))
+        var vmApi = client.Nodes[item.Node].Lxc[item.VmId];
+        var firewallTask = vmApi.Firewall.Options.GetAsync();
+        var pendingTask = vmApi.Pending.GetAsync();
+        var snapshotTask = settings.Snapshot.Enabled ? vmApi.Snapshot.GetAsync() : Task.FromResult<IEnumerable<VmSnapshot>>([]);
+        await Task.WhenAll(firewallTask, pendingTask, snapshotTask);
+        return new ContainerFetchData(item, (VmConfigLxc)_vmConfigs[item.VmId],
+                                      firewallTask.Result, pendingTask.Result, snapshotTask.Result);
+    }
+
+    private async Task CheckContainerAsync()
+    {
+        var ctItems = _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
+                                           && a.VmType == VmType.Lxc
+                                           && !a.IsTemplate).ToList();
+        var ctFetchResults = await RunParallelAsync(ctItems, FetchContainerDataAsync);
+
+        foreach (var fetch in ctFetchResults)
         {
-            var vmApi = client.Nodes[item.Node].Lxc[item.VmId];
+            var item = fetch.Item;
+            var lxcConfig = fetch.Config;
             var id = item.GetWebUrl();
-            var lxcConfig = (VmConfigLxc)_vmConfigs[item.VmId];
 
             #region Firewall and IP filter
-            CheckVmFirewall(_result, await vmApi.Firewall.Options.GetAsync(), id, DiagnosticResultContext.Lxc);
+            CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Lxc);
             #endregion
 
             if (lxcConfig is VmConfigLxc lxc)
@@ -62,13 +83,13 @@ public partial class DiagnosticEngine
 
                     // Privileged container with AppArmor explicitly disabled via features=apparmor=0
                     // or via raw lxc.apparmor.profile=unconfined — no kernel confinement at all
-                    var appArmorDisabledViaFeatures = (lxc.Features ?? string.Empty)
+                    var appArmorDisabledViaFeatures = (lxc.Features ?? "")
                         .Split(',')
                         .Any(p => p.Trim().Equals("apparmor=0", StringComparison.OrdinalIgnoreCase));
 
                     var appArmorDisabledViaRaw = lxcConfig.ExtensionData?.Any(kv =>
                         kv.Key.Equals("lxc.apparmor.profile", StringComparison.OrdinalIgnoreCase)
-                        && kv.Value?.ToString()?.Equals("unconfined", StringComparison.OrdinalIgnoreCase) == true) == true;
+                        && kv.Value?.ToString()?.Equals("unconfined", StringComparison.OrdinalIgnoreCase) is true) is true;
 
                     if (appArmorDisabledViaFeatures || appArmorDisabledViaRaw)
                     {
@@ -155,11 +176,9 @@ public partial class DiagnosticEngine
             await CheckCommonVmAsync(settings,
                                      settings.Lxc,
                                      lxcConfig,
-                                     await vmApi.Pending.GetAsync(),
-                                     settings.Snapshot.Enabled
-                                        ? await vmApi.Snapshot.GetAsync()
-                                        : [],
-                                     await vmApi.Rrddata.GetAsync(settings.Lxc.Rrd.TimeFrame, settings.Lxc.Rrd.Consolidation),
+                                     fetch.Pending,
+                                     fetch.Snapshots,
+                                     await client.Nodes[item.Node].Lxc[item.VmId].Rrddata.GetAsync(settings.Lxc.Rrd.TimeFrame, settings.Lxc.Rrd.Consolidation),
                                      DiagnosticResultContext.Lxc,
                                      item.Node,
                                      item.VmId,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
+
+public partial class DiagnosticEngine
+{
+    // PVE major version → Debian release name
+    private static readonly Dictionary<int, string> _pveToDebian = new()
+    {
+        { 9, "trixie"   },
+        { 8, "bookworm" },
+        { 7, "bullseye" },
+        { 6, "buster"   },
+    };
+
+    private static readonly string[] _cvssMetricKeys = ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"];
+
+    // Debian Tracker: package → CVE → (status, urgency) — filtered to the detected release at parse time
+    private record DebianCveEntry(string Status, string Urgency);
+
+    // NVD CVE entry — only what we need
+    private record NvdCveEntry(string Id,
+                               string Description,
+                               double? CvssScore,
+                               string? Severity,
+                               string? VersionStart,
+                               string? VersionEnd);
+
+    private Dictionary<string, Dictionary<string, DebianCveEntry>>? _debianCveData;
+    private List<NvdCveEntry>? _nvdCveData;
+
+    private async Task FetchCveDataAsync(int pveMajorVersion)
+    {
+        var debianRelease = _pveToDebian.GetValueOrDefault(pveMajorVersion, "bookworm");
+
+        httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("cv4pve-diag/1.0");
+
+        var tasks = new List<Task>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+
+        if (settings.Cve.DebianTrackerEnabled)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                try
+                {
+                    await using var stream = await httpClient.GetStreamAsync("https://security-tracker.debian.org/tracker/data/json", cts.Token);
+                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
+                    var result = new Dictionary<string, Dictionary<string, DebianCveEntry>>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var pkg in doc.RootElement.EnumerateObject())
+                    {
+                        var cveMap = new Dictionary<string, DebianCveEntry>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var cve in pkg.Value.EnumerateObject())
+                        {
+                            if (!cve.Value.TryGetProperty("releases", out var releases)) { continue; }
+
+                            // Filter at parse time — keep only the detected Debian release
+                            if (!releases.TryGetProperty(debianRelease, out var rel)) { continue; }
+
+                            var status = rel.TryGetProperty("status", out var s) ? s.GetString() ?? "" : "";
+                            var urgency = rel.TryGetProperty("urgency", out var u) ? u.GetString() ?? "" : "";
+
+                            if (status != "open") { continue; }
+                            if (urgency is "unimportant" or "end-of-life") { continue; }
+
+                            cveMap[cve.Name] = new DebianCveEntry(status, urgency);
+                        }
+                        if (cveMap.Count > 0) { result[pkg.Name] = cveMap; }
+                    }
+                    _debianCveData = result;
+                }
+                catch { _debianCveData = []; }
+            }));
+        }
+
+        if (settings.Cve.NvdEnabled)
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                try
+                {
+                    await using var stream = await httpClient.GetStreamAsync("https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=proxmox&resultsPerPage=100", cts.Token);
+                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
+                    var result = new List<NvdCveEntry>();
+                    if (!doc.RootElement.TryGetProperty("vulnerabilities", out var vulns)) { return; }
+
+                    foreach (var vuln in vulns.EnumerateArray())
+                    {
+                        if (!vuln.TryGetProperty("cve", out var cve)) { continue; }
+                        var id = cve.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
+
+                        // Description (English only)
+                        var desc = "";
+                        if (cve.TryGetProperty("descriptions", out var descs))
+                        {
+                            foreach (var d in descs.EnumerateArray())
+                            {
+                                if (d.TryGetProperty("lang", out var lang) && lang.GetString() == "en")
+                                {
+                                    desc = d.TryGetProperty("value", out var v) ? v.GetString() ?? "" : "";
+                                    break;
+                                }
+                            }
+                        }
+
+                        // CVSS score — prefer v31, fallback v30, fallback v2
+                        double? score = null;
+                        string? severity = null;
+                        if (cve.TryGetProperty("metrics", out var metrics))
+                        {
+                            foreach (var metricKey in _cvssMetricKeys)
+                            {
+                                if (!metrics.TryGetProperty(metricKey, out var metricArr)) { continue; }
+                                foreach (var m in metricArr.EnumerateArray())
+                                {
+                                    if (!m.TryGetProperty("cvssData", out var cvssData)) { continue; }
+                                    if (cvssData.TryGetProperty("baseScore", out var bs)) { score = bs.GetDouble(); }
+                                    if (m.TryGetProperty("baseSeverity", out var sev)) { severity = sev.GetString(); }
+                                    else if (cvssData.TryGetProperty("baseSeverity", out var sev2)) { severity = sev2.GetString(); }
+                                    break;
+                                }
+                                if (score.HasValue) { break; }
+                            }
+                        }
+
+                        // Filter by MinCvssScore at parse time
+                        if (score < settings.Cve.MinCvssScore) { continue; }
+
+                        // Version range from CPE — first proxmox:virtual_environment entry
+                        string? versionStart = null, versionEnd = null;
+                        if (cve.TryGetProperty("configurations", out var configs))
+                        {
+                            foreach (var config in configs.EnumerateArray())
+                            {
+                                if (!config.TryGetProperty("nodes", out var nodes)) { continue; }
+                                foreach (var node in nodes.EnumerateArray())
+                                {
+                                    if (!node.TryGetProperty("cpeMatch", out var cpeMatches)) { continue; }
+                                    foreach (var cpe in cpeMatches.EnumerateArray())
+                                    {
+                                        if (!cpe.TryGetProperty("criteria", out var criteria)) { continue; }
+                                        if (!criteria.GetString()!.Contains("proxmox:virtual_environment", StringComparison.OrdinalIgnoreCase)) { continue; }
+                                        if (cpe.TryGetProperty("versionStartIncluding", out var vs)) { versionStart = vs.GetString(); }
+                                        if (cpe.TryGetProperty("versionEndExcluding", out var ve)) { versionEnd = ve.GetString(); }
+                                        else if (cpe.TryGetProperty("versionEndIncluding", out var vi)) { versionEnd = vi.GetString(); }
+                                        break;
+                                    }
+                                    if (versionStart != null || versionEnd != null) { break; }
+                                }
+                                if (versionStart != null || versionEnd != null) { break; }
+                            }
+                        }
+
+                        // Skip CVE with no CPE for proxmox:virtual_environment (Salt, Jenkins, Foreman, Terraform, etc.)
+                        if (versionStart == null && versionEnd == null) { continue; }
+
+                        // Skip CVE with no upper version bound — cannot determine if current version is affected
+                        if (string.IsNullOrWhiteSpace(versionEnd)) { continue; }
+
+                        result.Add(new NvdCveEntry(id, desc, score, severity, versionStart, versionEnd));
+                    }
+                    _nvdCveData = result;
+                }
+                catch { _nvdCveData = []; }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+    }
+
+    // Compare two version strings numerically segment by segment (e.g. "8.1.4" vs "7.2-3").
+    // Non-numeric segments are compared as strings. Returns negative if a < b, 0 if equal, positive if a > b.
+    private static int CompareVersions(string a, string b)
+    {
+        var aParts = a.Split('.', '-');
+        var bParts = b.Split('.', '-');
+        var len = Math.Max(aParts.Length, bParts.Length);
+        for (var i = 0; i < len; i++)
+        {
+            var aSeg = i < aParts.Length ? aParts[i] : "0";
+            var bSeg = i < bParts.Length ? bParts[i] : "0";
+            var cmp = int.TryParse(aSeg, out var aNum) && int.TryParse(bSeg, out var bNum)
+                        ? aNum.CompareTo(bNum)
+                        : string.Compare(aSeg, bSeg, StringComparison.OrdinalIgnoreCase);
+            if (cmp != 0) { return cmp; }
+        }
+        return 0;
+    }
+
+    private void CheckNodeCve(string id, IEnumerable<NodeAptVersion> aptVersions)
+    {
+        // Debian Security Tracker — data already filtered to the correct release at fetch time
+        if (settings.Cve.DebianTrackerEnabled && _debianCveData != null)
+        {
+            foreach (var pkg in aptVersions)
+            {
+                if (string.IsNullOrWhiteSpace(pkg.Package)) { continue; }
+                if (!_debianCveData.TryGetValue(pkg.Package, out var cveMap)) { continue; }
+
+                foreach (var (cveId, entry) in cveMap)
+                {
+                    var gravity = entry.Urgency switch
+                    {
+                        "high"             => DiagnosticResultGravity.Critical,
+                        "medium"           => DiagnosticResultGravity.Warning,
+                        "not yet assigned" => DiagnosticResultGravity.Warning, // open CVE, fix not yet available
+                        _                  => DiagnosticResultGravity.Info,
+                    };
+
+                    _result.Add(new DiagnosticResult
+                    {
+                        Id = id,
+                        ErrorCode = gravity == DiagnosticResultGravity.Critical ? "CN0014" : "WN0041",
+                        Description = $"Package '{pkg.Package}' ({pkg.Version}) has open CVE {cveId} (urgency: {entry.Urgency})",
+                        Context = DiagnosticResultContext.Node,
+                        SubContext = "CVE",
+                        Gravity = gravity,
+                    });
+                }
+            }
+        }
+
+        // NVD — Proxmox VE specific CVE, already filtered by MinCvssScore at fetch time
+        if (settings.Cve.NvdEnabled && _nvdCveData != null)
+        {
+            var pvePkg = aptVersions.FirstOrDefault(p => p.Package?.Equals("pve-manager", StringComparison.OrdinalIgnoreCase) is true);
+            var pveVerStr = pvePkg?.Version ?? "";
+
+            foreach (var cve in _nvdCveData)
+            {
+                // Skip if installed pve-manager version is beyond the vulnerable range
+                if (!string.IsNullOrWhiteSpace(pveVerStr) && !string.IsNullOrWhiteSpace(cve.VersionEnd))
+                {
+                    if (CompareVersions(pveVerStr, cve.VersionEnd) > 0) { continue; }
+                }
+
+                var gravity = cve.CvssScore switch
+                {
+                    >= 9.0 => DiagnosticResultGravity.Critical,
+                    >= 7.0 => DiagnosticResultGravity.Warning,
+                    _ => DiagnosticResultGravity.Info,
+                };
+
+                _result.Add(new DiagnosticResult
+                {
+                    Id = id,
+                    ErrorCode = gravity == DiagnosticResultGravity.Critical ? "CN0015" : "WN0042",
+                    Description = $"Proxmox CVE {cve.Id} (CVSS: {cve.CvssScore:F1}, {cve.Severity}): {cve.Description}",
+                    Context = DiagnosticResultContext.Node,
+                    SubContext = "CVE",
+                    Gravity = gravity,
+                });
+            }
+        }
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
@@ -209,10 +209,10 @@ public partial class DiagnosticEngine
                 {
                     var gravity = entry.Urgency switch
                     {
-                        "high"             => DiagnosticResultGravity.Critical,
-                        "medium"           => DiagnosticResultGravity.Warning,
+                        "high" => DiagnosticResultGravity.Critical,
+                        "medium" => DiagnosticResultGravity.Warning,
                         "not yet assigned" => DiagnosticResultGravity.Warning, // open CVE, fix not yet available
-                        _                  => DiagnosticResultGravity.Info,
+                        _ => DiagnosticResultGravity.Info,
                     };
 
                     _result.Add(new DiagnosticResult

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
@@ -32,29 +32,84 @@ public partial class DiagnosticEngine
                                    NodeAptRepositories? AptRepositories,
                                    IEnumerable<NodeNetwork> Networks);
 
+    private record NodeFetchData(ClusterResource Item,
+                                 NodeSubscription Subscription,
+                                 IEnumerable<NodeService> Services,
+                                 IEnumerable<NodeCertificate> Certificates,
+                                 IEnumerable<NodeReplication> Replication,
+                                 IEnumerable<NodeAptUpdate> AptUpdate,
+                                 IEnumerable<NodeHardwarePci> PciDevices,
+                                 IEnumerable<NodeTask> Tasks,
+                                 IEnumerable<NodeDiskList> Disks,
+                                 IEnumerable<NodeDiskZfs> ZfsList,
+                                 IEnumerable<NodeDiskLvmThin> LvmThinList);
+
+    private async Task<NodeFetchData> FetchNodeDataAsync(ClusterResource item)
+    {
+        var api = client.Nodes[item.Node];
+        var subscriptionTask = api.Subscription.GetAsync();
+        var servicesTask = api.Services.GetAsync();
+        var certificatesTask = api.Certificates.Info.GetAsync();
+        var replicationTask = api.Replication.GetAsync();
+        var aptUpdateTask = api.Apt.Update.GetAsync();
+        var pciTask = api.Hardware.Pci.GetAsync();
+        var tasksTask = api.Tasks.GetAsync(errors: true, limit: 1000);
+        var disksListTask = api.Disks.List.GetAsync(include_partitions: false);
+        var zfsListTask = api.Disks.Zfs.GetAsync();
+        var lvmThinListTask = settings.Node.NodeStorage.LvmThinMetadata
+                                    ? api.Disks.Lvmthin.GetAsync()
+                                    : Task.FromResult<IEnumerable<NodeDiskLvmThin>>([]);
+        await Task.WhenAll(subscriptionTask, servicesTask, certificatesTask, replicationTask,
+                           aptUpdateTask, pciTask, tasksTask, disksListTask, zfsListTask, lvmThinListTask);
+
+        return new NodeFetchData(item,
+                                 subscriptionTask.Result,
+                                 servicesTask.Result,
+                                 certificatesTask.Result,
+                                 replicationTask.Result,
+                                 aptUpdateTask.Result,
+                                 pciTask.Result,
+                                 tasksTask.Result,
+                                 disksListTask.Result,
+                                 zfsListTask.Result ?? [],
+                                 lvmThinListTask.Result ?? []);
+    }
+
     private async Task CheckNodesAsync(bool hasCluster)
     {
         var onlineNodes = _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline).ToList();
 
-        // Pre-fetch lightweight per-node data once to avoid redundant API calls during cross-node comparisons
-        var nodeCompareData = new Dictionary<string, NodeCompareData>();
-        foreach (var item in onlineNodes)
+        // Pre-fetch lightweight per-node data — nodes in parallel, 8 calls per node in parallel
+        var nodeCompareResults = await RunParallelAsync(onlineNodes, async item =>
         {
             var api = client.Nodes[item.Node];
-            var timeRaw = (await api.Time.Time()).ToData();
+            var versionTask = api.Version.GetAsync();
+            var hostsTask = api.Hosts.GetEtcHosts();
+            var dnsTask = api.Dns.GetAsync();
+            var aptVersionsTask = api.Apt.Versions.GetAsync();
+            var statusTask = api.Status.GetAsync();
+            var aptRepositoriesTask = api.Apt.Repositories.GetAsync();
+            var networksTask = api.Network.GetAsync();
+            var timeTask = api.Time.Time();
+            await Task.WhenAll(versionTask, hostsTask, dnsTask, aptVersionsTask,
+                               statusTask, aptRepositoriesTask, networksTask, timeTask);
 
-            nodeCompareData[item.Node] = new NodeCompareData(await api.Version.GetAsync(),
-                                                             ((string)(await api.Hosts.GetEtcHosts()).ToData().data).Split('\n'),
-                                                             await api.Dns.GetAsync(),
-                                                             timeRaw.timezone as string ?? string.Empty,
-                                                             await api.Apt.Versions.GetAsync(),
-                                                             await api.Status.GetAsync(),
-                                                             timeRaw.time is long t
-                                                                ? t
-                                                                : 0L,
-                                                             await api.Apt.Repositories.GetAsync(),
-                                                             await api.Network.GetAsync());
-        }
+            var timeRaw = timeTask.Result.ToData();
+            return (item.Node, Data: new NodeCompareData(versionTask.Result,
+                                                         ((string)hostsTask.Result.ToData().data).Split('\n'),
+                                                         dnsTask.Result,
+                                                         timeRaw.timezone as string ?? "",
+                                                         aptVersionsTask.Result,
+                                                         statusTask.Result,
+                                                         timeRaw.time is long t ? t : 0L,
+                                                         aptRepositoriesTask.Result,
+                                                         networksTask.Result));
+        });
+        var nodeCompareData = nodeCompareResults.ToDictionary(r => r.Node, r => r.Data);
+
+        // Pre-fetch all per-node data in parallel (subscription, services, certs, replication, apt, pci, tasks, disks)
+        var nodeFetchResults = await RunParallelAsync(onlineNodes, FetchNodeDataAsync);
+        var nodeFetchData = nodeFetchResults.ToDictionary(r => r.Item.Node, r => r);
 
         foreach (var item in _resources.Where(a => a.ResourceType == ClusterResourceType.Node))
         {
@@ -94,10 +149,11 @@ public partial class DiagnosticEngine
             }
             #endregion
 
+            var fetch = nodeFetchData[item.Node];
+
             #region Subscription
             // Without an active subscription the node uses the community repo and has no enterprise support
-            var subscription = await nodeApi.Subscription.GetAsync();
-            if (!subscription.Status.Equals("active", StringComparison.CurrentCultureIgnoreCase))
+            if (!fetch.Subscription.Status.Equals("active", StringComparison.CurrentCultureIgnoreCase))
             {
                 _result.Add(new DiagnosticResult
                 {
@@ -297,7 +353,7 @@ public partial class DiagnosticEngine
                                     ? "systemd-timesyncd"
                                     : "chrony");
 
-            _result.AddRange((await nodeApi.Services.GetAsync())
+            _result.AddRange(fetch.Services
                             .Where(a => !a.IsRunning && !serviceExcluded.Contains(a.Name))
                             .Select(a => new DiagnosticResult
                             {
@@ -312,7 +368,7 @@ public partial class DiagnosticEngine
 
             #region Certificates
             // Expired TLS certificates break the web UI and API access
-            _result.AddRange((await nodeApi.Certificates.Info.GetAsync())
+            _result.AddRange(fetch.Certificates
                               .Where(a => DateTimeOffset.FromUnixTimeSeconds(a.NotAfter) < _now)
                               .Select(a => new DiagnosticResult
                               {
@@ -327,8 +383,7 @@ public partial class DiagnosticEngine
 
             #region Replication
             // Replication jobs with errors mean the secondary copy is out of date
-            var replCount = (await nodeApi.Replication.GetAsync())
-                                .Count(a => a.ExtensionData?.ContainsKey("errors") == true);
+            var replCount = fetch.Replication.Count(a => a.ExtensionData?.ContainsKey("errors") is true);
             if (replCount > 0)
             {
                 _result.Add(new DiagnosticResult
@@ -343,11 +398,11 @@ public partial class DiagnosticEngine
             }
             #endregion
 
-            await CheckNodeDiskAsync(nodeApi, settings, id);
+            await CheckNodeDiskAsync(nodeApi, settings, id, fetch);
 
             #region APT Updates
             // Any pending update is informational; "important" priority updates (security) are Warning
-            var aptUpdate = await nodeApi.Apt.Update.GetAsync();
+            var aptUpdate = fetch.AptUpdate;
             var updateCount = aptUpdate.Count();
             if (updateCount > 0)
             {
@@ -383,7 +438,7 @@ public partial class DiagnosticEngine
             {
                 // Kversion contains the full uname string; CurrentKernel.Release is the running kernel
                 // Compare the running kernel release against the installed kversion string
-                var runningKernel = nodeStatus.CurrentKernel?.Release ?? string.Empty;
+                var runningKernel = nodeStatus.CurrentKernel?.Release ?? "";
                 if (!string.IsNullOrWhiteSpace(runningKernel) && !nodeStatus.Kversion.Contains(runningKernel))
                 {
                     _result.Add(new DiagnosticResult
@@ -423,7 +478,7 @@ public partial class DiagnosticEngine
             // IOMMU is required for PCI passthrough (GPU, NIC, etc.).
             // If all detected PCI devices report IommuGroup == -1 the kernel/firmware has IOMMU disabled.
             // Note: a node with no PCI devices at all is not flagged.
-            var pciDevices = await nodeApi.Hardware.Pci.GetAsync();
+            var pciDevices = fetch.PciDevices;
             if (pciDevices.Any() && pciDevices.All(a => a.IommuGroup == -1))
             {
                 _result.Add(new DiagnosticResult
@@ -441,8 +496,13 @@ public partial class DiagnosticEngine
             #region Task history
             // Failed tasks in the last 48 hours (errors=true filters server-side for efficiency)
             var dayTask = new DateTimeOffset(_now.AddDays(-2)).ToUnixTimeSeconds();
-            var tasks = (await nodeApi.Tasks.GetAsync(errors: true, limit: 1000)).Where(a => a.StartTime >= dayTask);
-            CheckTaskHistory(_result, tasks, DiagnosticResultContext.Node, id);
+            CheckTaskHistory(_result,
+                             fetch.Tasks.Where(a => a.StartTime >= dayTask),
+                             DiagnosticResultContext.Node, id);
+            #endregion
+
+            #region CVE
+            CheckNodeCve(id, aptVersions);
             #endregion
 
             // TODO: backup history anomaly check — uncomment when BackupHelper.ParseVzdumpLog is available via NuGet.
@@ -512,7 +572,7 @@ public partial class DiagnosticEngine
 
             // Build set of non-VLAN-aware bridge names on this node
             var nonVlanBridges = nodeData.Networks
-                                         .Where(n => n.Type == "bridge" && n.BridgeVlanAware != true)
+                                         .Where(n => n.Type == "bridge" && n.BridgeVlanAware is not true)
                                          .Select(n => n.Interface)
                                          .ToHashSet();
 
@@ -779,7 +839,7 @@ public partial class DiagnosticEngine
                 {
                     Id = id,
                     ErrorCode = "CN0012",
-                    Description = $"ZFS pool '{poolName}' vdev '{child.Name}' is {child.State}{(string.IsNullOrWhiteSpace(child.Msg) ? string.Empty : $": {child.Msg}")}",
+                    Description = $"ZFS pool '{poolName}' vdev '{child.Name}' is {child.State}{(string.IsNullOrWhiteSpace(child.Msg) ? "" : $": {child.Msg}")}",
                     Context = DiagnosticResultContext.Node,
                     SubContext = "Zfs",
                     Gravity = DiagnosticResultGravity.Critical,
@@ -807,11 +867,12 @@ public partial class DiagnosticEngine
 
     private async Task CheckNodeDiskAsync(PveClient.PveNodes.PveNodeItem nodeApi,
                                           Settings settings,
-                                          string id)
+                                          string id,
+                                          NodeFetchData fetch)
     {
         #region Disks
         // S.M.A.R.T. status: anything other than PASSED/OK indicates a failing or failed disk
-        var disksAll = await nodeApi.Disks.List.GetAsync(include_partitions: false);
+        var disksAll = fetch.Disks;
 
         _result.AddRange(disksAll.Where(a => a.Health != "PASSED" && a.Health != "OK")
                                  .Select(a => new DiagnosticResult
@@ -850,9 +911,11 @@ public partial class DiagnosticEngine
         // Detailed S.M.A.R.T. attribute checks — one API call per disk, disabled by default
         if (settings.Node.Smart.Enabled)
         {
-            foreach (var disk in disksAll.Where(a => !string.IsNullOrWhiteSpace(a.DevPath)))
+            var smartResults = await RunParallelAsync(disksAll.Where(a => !string.IsNullOrWhiteSpace(a.DevPath)),
+                                                      d => nodeApi.Disks.Smart.GetAsync(disk: d.DevPath));
+
+            foreach (var (disk, smart) in disksAll.Where(a => !string.IsNullOrWhiteSpace(a.DevPath)).ToList().Zip(smartResults))
             {
-                var smart = await nodeApi.Disks.Smart.GetAsync(disk: disk.DevPath);
                 if (smart?.Attributes == null) { continue; }
 
                 foreach (var attr in smart.Attributes)
@@ -958,8 +1021,7 @@ public partial class DiagnosticEngine
 
         #region Zfs
         // ZFS pool health: anything other than ONLINE means degraded/faulted pool
-        var zfsList = await nodeApi.Disks.Zfs.GetAsync() ?? [];
-
+        var zfsList = fetch.ZfsList;
         _result.AddRange(zfsList.Where(a => a.Health != "ONLINE")
                                 .Select(a => new DiagnosticResult
                                 {
@@ -987,9 +1049,9 @@ public partial class DiagnosticEngine
         // Detailed ZFS checks: pool errors and vdev state — one API call per pool
         if (settings.Node.NodeStorage.ZfsDetail && zfsList.Any())
         {
-            foreach (var zfs in zfsList)
+            var zfsDetails = await RunParallelAsync(zfsList, zfs => nodeApi.Disks.Zfs[zfs.Name].GetAsync());
+            foreach (var (zfs, detail) in zfsList.Zip(zfsDetails))
             {
-                var detail = await nodeApi.Disks.Zfs[zfs.Name].GetAsync();
                 if (detail == null) { continue; }
 
                 // Pool-level errors string (e.g. "1 data errors, use '-v' for a list")
@@ -1017,7 +1079,7 @@ public partial class DiagnosticEngine
         // LVM-thin metadata pool full causes silent data corruption — check before it's too late
         if (settings.Node.NodeStorage.LvmThinMetadata)
         {
-            var lvmThinList = await nodeApi.Disks.Lvmthin.GetAsync() ?? [];
+            var lvmThinList = fetch.LvmThinList;
             foreach (var lv in lvmThinList.Where(a => a.MetadataSize > 0))
             {
                 var metaPct = (double)lv.MetadataUsed / lv.MetadataSize * 100.0;

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
@@ -147,7 +147,7 @@ public partial class DiagnosticEngine
         // than physically available. If the sum of all VM disk sizes exceeds the storage capacity
         // the storage will silently fill up and VMs will crash or freeze.
         foreach (var storage in _storageResources.Where(a => a.IsAvailable
-                                                              && _thinProvisioningTypes.Contains(a.PluginType ?? string.Empty)
+                                                              && _thinProvisioningTypes.Contains(a.PluginType ?? "")
                                                               && a.DiskSize > 0))
         {
             if (!allocatedByStorage.TryGetValue(storage.Storage, out var allocated)) { continue; }
@@ -169,7 +169,7 @@ public partial class DiagnosticEngine
 
         #region No storage with backup content type
         // If no storage in the cluster has 'backup' as a content type, vzdump has nowhere to save backups.
-        var hasBackupStorage = _storageResources.Any(a => a.Content?.Split(',').Contains("backup") == true);
+        var hasBackupStorage = _storageResources.Any(a => a.Content?.Split(',').Contains("backup") is true);
         if (!hasBackupStorage)
         {
             _result.Add(new DiagnosticResult
@@ -227,7 +227,7 @@ public partial class DiagnosticEngine
             // Use full _resources to count how many nodes mount each storage
             var storagesByName = _resources.Where(a => a.ResourceType == ClusterResourceType.Storage && a.IsAvailable)
                                            .GroupBy(a => a.Storage)
-                                           .Where(g => _sharedStorageTypes.Contains(g.First().PluginType ?? string.Empty) && g.Count() == 1)
+                                           .Where(g => _sharedStorageTypes.Contains(g.First().PluginType ?? "") && g.Count() == 1)
                                            .Select(g => g.First());
 
             _result.AddRange(storagesByName.Select(a => new DiagnosticResult

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
@@ -5,6 +5,7 @@
 
 using Corsinvest.ProxmoxVE.Api.Extension;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Cluster;
+using Corsinvest.ProxmoxVE.Api.Shared.Models.Common;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 
 namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
@@ -25,7 +26,33 @@ public partial class DiagnosticEngine
     // win8  covers Win8/2012/2012R2 — all EOL (Oct 2023).
     private static readonly string[] _osNotMaintained = ["win8", "win7", "wvista", "w2k8", "w2k3", "wxp", "w2k"];
 
-    private async Task CheckQemuAsync(bool hasCluster)
+    private record VmFetchData(ClusterResource Item,
+                               VmConfigQemu Config,
+                               VmFirewallOptions Firewall,
+                               IEnumerable<KeyValue> Pending,
+                               IEnumerable<VmSnapshot> Snapshots,
+                               object? AgentInfo);
+
+    private async Task<VmFetchData> FetchVmDataAsync(ClusterResource item)
+    {
+        var vmApi = client.Nodes[item.Node].Qemu[item.VmId];
+        var config = (VmConfigQemu)_vmConfigs[item.VmId];
+        var firewallTask = vmApi.Firewall.Options.GetAsync();
+        var pendingTask = vmApi.Pending.GetAsync();
+        var snapshotTask = settings.Snapshot.Enabled ? vmApi.Snapshot.GetAsync() : Task.FromResult<IEnumerable<VmSnapshot>>([]);
+        await Task.WhenAll(firewallTask, pendingTask, snapshotTask);
+
+        object? agentInfo = null;
+        if (config.AgentEnabled && item.IsRunning)
+        {
+            try { agentInfo = await vmApi.Agent.Info.GetAsync(); }
+            catch { /* agent not running — handled in check */ }
+        }
+
+        return new VmFetchData(item, config, firewallTask.Result, pendingTask.Result, snapshotTask.Result, agentInfo);
+    }
+
+    private async Task CheckVmAsync(bool hasCluster)
     {
         // Build set of VM IDs managed by HA from already-loaded resources
         var haVmIds = _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
@@ -64,14 +91,17 @@ public partial class DiagnosticEngine
             }
         }
 
-        foreach (var item in _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
-                                                  && a.VmType == VmType.Qemu
-                                                  && !a.IsTemplate))
+        // Pre-fetch all VM data in parallel
+        var vmFetchResults = await RunParallelAsync(_resources.Where(a => a.ResourceType == ClusterResourceType.Vm
+                                                                            && a.VmType == VmType.Qemu
+                                                                            && !a.IsTemplate),
+                                                    FetchVmDataAsync);
+
+        foreach (var fetch in vmFetchResults)
         {
-            var nodeApi = client.Nodes[item.Node];
-            var vmApi = nodeApi.Qemu[item.VmId];
+            var item = fetch.Item;
+            var config = fetch.Config;
             var id = item.GetWebUrl();
-            var config = (VmConfigQemu)_vmConfigs[item.VmId];
 
             #region OS
             // OsType drives several PVE defaults (RTC, drivers, etc.) — must be set correctly
@@ -115,43 +145,23 @@ public partial class DiagnosticEngine
                     Gravity = DiagnosticResultGravity.Warning,
                 });
             }
-            else if (item.IsRunning)
+            else if (item.IsRunning && fetch.AgentInfo == null)
             {
-                // agent/info: verify agent is running and retrieve version for outdated check
-                try
+                _result.Add(new DiagnosticResult
                 {
-                    var agentInfo = await vmApi.Agent.Info.GetAsync();
-                    if (agentInfo?.Result == null)
-                    {
-                        _result.Add(new DiagnosticResult
-                        {
-                            Id = id,
-                            ErrorCode = "WG0004",
-                            Description = "Qemu Agent in guest not running",
-                            Context = DiagnosticResultContext.Qemu,
-                            SubContext = "Agent",
-                            Gravity = DiagnosticResultGravity.Warning,
-                        });
-                    }
-                }
-                catch
-                {
-                    _result.Add(new DiagnosticResult
-                    {
-                        Id = id,
-                        ErrorCode = "WG0004",
-                        Description = "Qemu Agent in guest not running",
-                        Context = DiagnosticResultContext.Qemu,
-                        SubContext = "Agent",
-                        Gravity = DiagnosticResultGravity.Warning,
-                    });
-                }
+                    Id = id,
+                    ErrorCode = "WG0004",
+                    Description = "Qemu Agent in guest not running",
+                    Context = DiagnosticResultContext.Qemu,
+                    SubContext = "Agent",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
             }
             #endregion
 
             #region Virtio
             // VirtIO SCSI controller and disk bus offer significantly better throughput than IDE/SATA emulation
-            if (config is VmConfigQemu qc && !(qc.ScsiHw ?? string.Empty).StartsWith(VirtioPrefix, StringComparison.OrdinalIgnoreCase))
+            if (config is VmConfigQemu qc && !(qc.ScsiHw ?? "").StartsWith(VirtioPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 _result.Add(new DiagnosticResult
                 {
@@ -265,7 +275,7 @@ public partial class DiagnosticEngine
                 if (!string.IsNullOrWhiteSpace(cpuType)
                     && !cpuType.Equals(CpuTypeHost, StringComparison.OrdinalIgnoreCase))
                 {
-                    var cpuFlags = qemuConfig.Cpu ?? string.Empty;
+                    var cpuFlags = qemuConfig.Cpu ?? "";
                     var missingFlags = _cpuSecurityFlags
                                         .Where(f => !cpuFlags.Contains(f, StringComparison.OrdinalIgnoreCase))
                                         .ToList();
@@ -292,7 +302,7 @@ public partial class DiagnosticEngine
                 if (!string.IsNullOrWhiteSpace(qemuConfig.Hotplug)
                     && qemuConfig.Hotplug != "0"
                     && qemuConfig.Hotplug.Split(',').Any(p => p.Trim() == "cpu")
-                    && config.OsType?.StartsWith("win", StringComparison.OrdinalIgnoreCase) == true)
+                    && config.OsType?.StartsWith("win", StringComparison.OrdinalIgnoreCase) is true)
                 {
                     _result.Add(new DiagnosticResult
                     {
@@ -499,7 +509,7 @@ public partial class DiagnosticEngine
             #endregion
 
             #region Firewall and IP filter
-            CheckVmFirewall(_result, await vmApi.Firewall.Options.GetAsync(), id, DiagnosticResultContext.Qemu);
+            CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Qemu);
             #endregion
 
             #region USB/PCI passthrough
@@ -526,11 +536,9 @@ public partial class DiagnosticEngine
             await CheckCommonVmAsync(settings,
                                      settings.Qemu,
                                      config,
-                                     await vmApi.Pending.GetAsync(),
-                                     settings.Snapshot.Enabled
-                                        ? await vmApi.Snapshot.GetAsync()
-                                        : [],
-                                     await vmApi.Rrddata.GetAsync(settings.Qemu.Rrd.TimeFrame, settings.Qemu.Rrd.Consolidation),
+                                     fetch.Pending,
+                                     fetch.Snapshots,
+                                     await client.Nodes[item.Node].Qemu[item.VmId].Rrddata.GetAsync(settings.Qemu.Rrd.TimeFrame, settings.Qemu.Rrd.Consolidation),
                                      DiagnosticResultContext.Qemu,
                                      item.Node,
                                      item.VmId,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
@@ -66,7 +66,7 @@ public partial class DiagnosticEngine(PveClient client, Settings settings, HttpC
 
             // Detect PVE major version from first online node — used to pick the correct Debian release for CVE filtering
             var firstOnlineNode = _resources.FirstOrDefault(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline);
-            var pveMajorVersion  = 8; // default to bookworm
+            var pveMajorVersion = 8; // default to bookworm
             if (firstOnlineNode != null)
             {
                 var ver = await client.Nodes[firstOnlineNode.Node].Version.GetAsync();

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
@@ -14,7 +14,7 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 /// <summary>
 /// Diagnostic helper
 /// </summary>
-public partial class DiagnosticEngine(PveClient client, Settings settings)
+public partial class DiagnosticEngine(PveClient client, Settings settings, HttpClient httpClient)
 {
     private readonly List<DiagnosticResult> _result = [];
     private readonly DateTime _now = DateTime.Now;
@@ -39,61 +39,94 @@ public partial class DiagnosticEngine(PveClient client, Settings settings)
     /// </summary>
     public async Task<ICollection<DiagnosticResult>> AnalyzeAsync(List<DiagnosticResult> ignoredIssues)
     {
-        var allResources = await client.Cluster.Resources.GetAsync();
-        _resources = [.. allResources.Where(a => !a.IsUnknown)];
+        var originalTimeout = client.Timeout;
+        if (settings.ApiTimeout > 0) { client.Timeout = TimeSpan.FromSeconds(settings.ApiTimeout); }
 
-        // Resources with unknown type are always a problem — report them all as Critical
-        _result.AddRange(allResources.Where(a => a.IsUnknown)
-                                     .Select(a => new DiagnosticResult
-                                     {
-                                         Id = a.GetWebUrl(),
-                                         ErrorCode = "CU0001",
-                                         Description = $"Unknown resource {a.Type}",
-                                         Context = DiagnosticResult.DecodeContext(a.Type),
-                                         SubContext = "Status",
-                                         Gravity = DiagnosticResultGravity.Critical,
-                                     }));
+        try
+        {
+            var allResources = await client.Cluster.Resources.GetAsync();
+            _resources = [.. allResources.Where(a => !a.IsUnknown)];
 
-        // Deduplicated storage list: shared → one record per storage name, non-shared → one per node
-        _storageResources = [.. _resources.Where(a => a.ResourceType == ClusterResourceType.Storage)
+            // Resources with unknown type are always a problem — report them all as Critical
+            _result.AddRange(allResources.Where(a => a.IsUnknown)
+                                         .Select(a => new DiagnosticResult
+                                         {
+                                             Id = a.GetWebUrl(),
+                                             ErrorCode = "CU0001",
+                                             Description = $"Unknown resource {a.Type}",
+                                             Context = DiagnosticResult.DecodeContext(a.Type),
+                                             SubContext = "Status",
+                                             Gravity = DiagnosticResultGravity.Critical,
+                                         }));
+
+            // Deduplicated storage list: shared → one record per storage name, non-shared → one per node
+            _storageResources = [.. _resources.Where(a => a.ResourceType == ClusterResourceType.Storage)
                                       .GroupBy(a => a.Shared ? a.Storage : $"{a.Node}/{a.Storage}")
                                       .Select(g => g.First())];
 
-        var hasCluster = await CheckClusterAsync();
-
-        // Pre-fetch backup storages once per node — shared by CheckQemuAsync and CheckLxcAsync
-        _backupStoragesByNode = [];
-        foreach (var node in _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline)
-                                       .Select(a => a.Node))
-        {
-            _backupStoragesByNode[node] = settings.Backup.Enabled
-                                            ? await client.Nodes[node].Storage.GetAsync(content: "backup", enabled: true)
-                                            : [];
-        }
-
-        // Pre-fetch VM configs once — shared by CheckQemuAsync, CheckLxcAsync, CheckStorageAsync
-        _vmConfigs = [];
-        foreach (var vm in _resources.Where(a => a.ResourceType == ClusterResourceType.Vm))
-        {
-            var nodeApi = client.Nodes[vm.Node];
-            _vmConfigs[vm.VmId] = vm.VmType == VmType.Qemu
-                                    ? await nodeApi.Qemu[vm.VmId].Config.GetAsync()
-                                    : await nodeApi.Lxc[vm.VmId].Config.GetAsync();
-        }
-
-        await CheckStorageAsync();
-        await CheckNodesAsync(hasCluster);
-        await CheckQemuAsync(hasCluster);
-        await CheckLxcAsync();
-
-        foreach (var ignoredIssue in ignoredIssues)
-        {
-            foreach (var item in _result.Where(a => ignoredIssue.CheckIgnoreIssue(a)))
+            // Detect PVE major version from first online node — used to pick the correct Debian release for CVE filtering
+            var firstOnlineNode = _resources.FirstOrDefault(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline);
+            var pveMajorVersion  = 8; // default to bookworm
+            if (firstOnlineNode != null)
             {
-                item.IsIgnoredIssue = true;
+                var ver = await client.Nodes[firstOnlineNode.Node].Version.GetAsync();
+                _ = int.TryParse(ver.Version?.Split('.')[0], out pveMajorVersion);
             }
-        }
 
-        return _result;
+            await FetchCveDataAsync(pveMajorVersion);
+
+            var hasCluster = await CheckClusterAsync();
+
+            // Pre-fetch backup storages once per node — shared by CheckQemuAsync and CheckLxcAsync
+            var backupStorageResults = await RunParallelAsync(_resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline)
+                                                                        .Select(a => a.Node),
+                                                              async node => new
+                                                              {
+                                                                  node,
+                                                                  storages = settings.Backup.Enabled
+                                                                                ? await client.Nodes[node].Storage.GetAsync(content: "backup", enabled: true)
+                                                                                : []
+                                                              });
+            _backupStoragesByNode = backupStorageResults.ToDictionary(a => a.node, a => a.storages);
+
+            // Pre-fetch VM configs once — shared by CheckQemuAsync, CheckLxcAsync, CheckStorageAsync
+            var vmConfigResults = await RunParallelAsync(_resources.Where(a => a.ResourceType == ClusterResourceType.Vm),
+                                                         async vm => new
+                                                         {
+                                                             vm.VmId,
+                                                             config = await client.GetVmConfigAsync(vm.Node, vm.VmType, vm.VmId)
+                                                         });
+            _vmConfigs = vmConfigResults.ToDictionary(r => r.VmId, r => r.config);
+
+            await CheckStorageAsync();
+            await CheckNodesAsync(hasCluster);
+            await CheckVmAsync(hasCluster);
+            await CheckContainerAsync();
+
+            foreach (var ignoredIssue in ignoredIssues)
+            {
+                foreach (var item in _result.Where(a => ignoredIssue.CheckIgnoreIssue(a)))
+                {
+                    item.IsIgnoredIssue = true;
+                }
+            }
+
+            return _result;
+        }
+        finally
+        {
+            client.Timeout = originalTimeout;
+        }
+    }
+
+    private async Task<TResult[]> RunParallelAsync<T, TResult>(IEnumerable<T> source, Func<T, Task<TResult>> func)
+    {
+        var semaphore = new SemaphoreSlim(settings.MaxParallelRequests);
+        return await Task.WhenAll(source.Select(async item =>
+        {
+            await semaphore.WaitAsync();
+            try { return await func(item); }
+            finally { semaphore.Release(); }
+        }));
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Settings.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Settings.cs
@@ -11,6 +11,16 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 public class Settings
 {
     /// <summary>
+    /// Max parallel requests when fetching (1 = sequential)
+    /// </summary>
+    public int MaxParallelRequests { get; set; } = 5;
+
+    /// <summary>
+    /// API timeout in seconds (0 = use default)
+    /// </summary>
+    public int ApiTimeout { get; set; } = 0;
+
+    /// <summary>
     /// Store
     /// </summary>
     /// <returns></returns>
@@ -67,5 +77,10 @@ public class Settings
     /// Backup checks configuration
     /// </summary>
     public SettingsBackup Backup { get; set; } = new();
+
+    /// <summary>
+    /// CVE checks configuration
+    /// </summary>
+    public SettingsCve Cve { get; set; } = new();
 
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
+
+/// <summary>
+/// Settings for CVE checks
+/// </summary>
+public class SettingsCve
+{
+    /// <summary>
+    /// Enable Debian Security Tracker checks.
+    /// Downloads CVE data for all Debian packages installed on each node.
+    /// Covers system packages (kernel, qemu, lxc, openssl, ...).
+    /// </summary>
+    public bool DebianTrackerEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Enable NVD checks for Proxmox-specific CVE.
+    /// Queries NVD API once with keywordSearch=proxmox to find CVE affecting PVE directly.
+    /// Optional API key speeds up the request (free at https://nvd.nist.gov/developers/request-an-api-key).
+    /// </summary>
+    public bool NvdEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Minimum CVSS v3 base score to report (0.0–10.0).
+    /// CVE with a score below this threshold are silently ignored.
+    /// Default: 7.0 (HIGH and CRITICAL only).
+    /// Set to 0 to report all CVE regardless of score.
+    /// </summary>
+    public double MinCvssScore { get; set; } = 7.0;
+}

--- a/src/Corsinvest.ProxmoxVE.Diagnostic/OutputEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic/OutputEngine.cs
@@ -36,7 +36,8 @@ internal class OutputEngine
                                 : [];
 
         var duration = Stopwatch.StartNew();
-        var result = await new DiagnosticEngine(client, settings!).AnalyzeAsync(ignoredIssues!);
+        using var httpClient = new HttpClient();
+        var result = await new DiagnosticEngine(client, settings!, httpClient).AnalyzeAsync(ignoredIssues!);
         duration.Stop();
 
         if (!string.IsNullOrWhiteSpace(outputFile)) { File.Delete(outputFile!); }
@@ -186,5 +187,4 @@ internal class OutputEngine
 
         workbook.SaveAs(fileName);
     }
-
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic/Program.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 var settingsFileName = "settings.json";
 var ignoredIssuesFileName = "ignored-issues.json";
 
-var app = ConsoleHelper.CreateApp("cv4pve-diag", "Diagnostic for Proxmox VE");
+var app = ConsoleHelper.CreateApp("Diagnostic for Proxmox VE");
 var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
 
 var optSettingsFile = app.AddOption<string>("--settings-file", "File settings (generated from create-settings)")
@@ -31,7 +31,7 @@ optOutput.DefaultValueFactory = (_) => OutputType.Text;
 var optOutputFile = app.AddOption<string>("--output-file", "Output file name");
 
 app.AddCommand("create-settings", $"Create file settings ({settingsFileName})")
-   .SetAction((action) =>
+   .SetAction((_) =>
    {
        File.WriteAllText(settingsFileName, JsonSerializer.Serialize(new Settings(), new JsonSerializerOptions { WriteIndented = true }));
        Console.Out.WriteLine(OutputEngine.PrintEnum("TimeFrame", typeof(RrdDataTimeFrame)));
@@ -40,7 +40,7 @@ app.AddCommand("create-settings", $"Create file settings ({settingsFileName})")
    });
 
 app.AddCommand("create-ignored-issues", $"Create File ignored issues ({ignoredIssuesFileName})")
-   .SetAction((action) =>
+   .SetAction((_) =>
    {
        File.WriteAllText(ignoredIssuesFileName, JsonSerializer.Serialize(new[] { new DiagnosticResult() }, new JsonSerializerOptions { WriteIndented = true }));
        Console.Out.WriteLine(OutputEngine.PrintEnum("Context", typeof(DiagnosticResultContext)));


### PR DESCRIPTION
## Summary

- **CVE scanning (opt-in)** — nuova sezione `Cve` nei settings con supporto Debian Security Tracker e NVD API 2.0; codici `CN0014`, `WN0041`, `CN0015`, `WN0042`
- **Parallelizzazione completa** — tutte le chiamate per-nodo (`FetchNodeDataAsync`: 10 call in parallelo), dati di confronto nodi, chiamate cluster, check SMART e ZFS detail usano `RunParallelAsync` / `Task.WhenAll`
- **`ApiTimeout` rispettato** — applicato all'inizio di `AnalyzeAsync`, ripristinato nel `finally`
- **`HttpClient` come parametro costruttore** — ciclo di vita gestito dal CLI
- **File rinominati** — `DiagnosticEngine.Qemu.cs` → `DiagnosticEngine.Vm.cs`, `DiagnosticEngine.Lxc.cs` → `DiagnosticEngine.Container.cs`
- **README** — sezione CVE Scanning aggiunta, tabella codici errore corretta e completata
- **Versione** aggiornata a `2.2.0`

## Test plan

- [ ] Build su net8/net9/net10
- [ ] `execute` con `Cve` disabilitato (default) — nessun risultato CVE, nessuna chiamata di rete
- [ ] `execute` con `DebianTrackerEnabled: true` — CVE rilevati per pacchetti con advisory aperti
- [ ] `execute` con `NvdEnabled: true` — CVE Proxmox filtrati per versione installata
- [ ] Run offline — sorgenti CVE ritornano `[]`, nessun crash
- [ ] Codici errore nell'output corrispondono alla tabella README