### PR TITLE
docs: document Sys.Modify permission and fix package licence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ---
 
+## [2.2.2] — 2026-04-18
+
+### Documentation
+
+- Documented the `Sys.Modify` permission requirement: Proxmox requires it even for read access to the APT update list (`/nodes/{node}/apt/update`).
+
+### Fixes
+
+- NuGet package license metadata corrected from `MIT` to `GPL-3.0-only` to match the project licence.
+
+
 ## [2.2.1] — 2026-04-17
 
 ### Fixes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.2.1</Version>
+    <Version>2.2.2</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/README.md
+++ b/README.md
@@ -73,12 +73,15 @@ All binaries on the [Releases page](https://github.com/Corsinvest/cv4pve-diag/re
 
 ### Required Permissions
 
-| Permission          | Purpose                                  | Scope            |
-| ------------------- | ---------------------------------------- | ---------------- |
-| **VM.Audit**        | Read VM/CT configuration and status      | Virtual machines |
-| **Datastore.Audit** | Check storage capacity and content       | Storage systems  |
-| **Pool.Audit**      | Access pool information                  | Resource pools   |
-| **Sys.Audit**       | Node system information, services, disks | Cluster nodes    |
+| Permission          | Purpose                                               | Scope            |
+| ------------------- | ----------------------------------------------------- | ---------------- |
+| **VM.Audit**        | Read VM/CT configuration and status                   | Virtual machines |
+| **Datastore.Audit** | Check storage capacity and content                    | Storage systems  |
+| **Pool.Audit**      | Access pool information                               | Resource pools   |
+| **Sys.Audit**       | Node system information, services, disks              | Cluster nodes    |
+| **Sys.Modify**      | Query APT package update list (`/nodes/{node}/apt/update`) | Cluster nodes    |
+
+> **Note:** Proxmox does not expose a dedicated read-only privilege for APT: the `/nodes/{node}/apt/update` endpoint requires `Sys.Modify` even for GET requests. Without it the diagnostic fails with `Permission check failed (/nodes/<node>, Sys.Modify)`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ Diagnostic Tool for Proxmox VE (Made in Italy)
 
 ---
 
+## Where cv4pve-diag fits
+
+The cv4pve suite follows the Unix philosophy — each tool does one thing and does it well. `cv4pve-diag` is focused on **finding problems**: it runs a fixed set of health checks and reports what is wrong.
+
+| Tool | Purpose | Output |
+|---|---|---|
+| [**cv4pve-diag**](https://github.com/Corsinvest/cv4pve-diag) | **Health checks** — detects misconfigurations, risks and best-practice violations | Issue list with severity |
+| [cv4pve-report](https://github.com/Corsinvest/cv4pve-report) | Cluster inventory and reporting | Excel workbook |
+
+> Use `cv4pve-diag` when you want to know *what is wrong*, `cv4pve-report` when you want to know *what you have*.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -73,15 +73,13 @@ All binaries on the [Releases page](https://github.com/Corsinvest/cv4pve-diag/re
 
 ### Required Permissions
 
-| Permission          | Purpose                                               | Scope            |
-| ------------------- | ----------------------------------------------------- | ---------------- |
-| **VM.Audit**        | Read VM/CT configuration and status                   | Virtual machines |
-| **Datastore.Audit** | Check storage capacity and content                    | Storage systems  |
-| **Pool.Audit**      | Access pool information                               | Resource pools   |
-| **Sys.Audit**       | Node system information, services, disks              | Cluster nodes    |
-| **Sys.Modify**      | Query APT package update list (`/nodes/{node}/apt/update`) | Cluster nodes    |
-
-> **Note:** Proxmox does not expose a dedicated read-only privilege for APT: the `/nodes/{node}/apt/update` endpoint requires `Sys.Modify` even for GET requests. Without it the diagnostic fails with `Permission check failed (/nodes/<node>, Sys.Modify)`.
+| Permission | Purpose | Scope |
+|------------|---------|-------|
+| **VM.Audit** | Read VM/CT configuration and status | Virtual machines |
+| **Datastore.Audit** | Check storage capacity and content | Storage systems |
+| **Pool.Audit** | Access pool information | Resource pools |
+| **Sys.Audit** | Node system information, services, disks | Cluster nodes |
+| **Sys.Modify** | APT repositories, available updates and installed package versions | Cluster nodes |
 
 </details>
 

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Corsinvest.ProxmoxVE.Diagnostic.Api.csproj
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Corsinvest.ProxmoxVE.Diagnostic.Api.csproj
@@ -7,7 +7,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>ProxmoxVE;Api,Client;Rest;Corsinvest;Diagnostic</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
     <PackageOutputPath>..\..\..\.nupkgs\</PackageOutputPath>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Corsinvest/cv4pve-diag</RepositoryUrl>


### PR DESCRIPTION
## Summary

- Document the `Sys.Modify` permission requirement in the README. Proxmox does not expose a dedicated read-only privilege for APT, so `/nodes/{node}/apt/update` requires `Sys.Modify` even for GET requests (reported in #30).
- Correct the NuGet package `PackageLicenseExpression` from `MIT` to `GPL-3.0-only` to match `LICENSE.md`.
- Bump version to 2.2.2 and update CHANGELOG.

## Test plan

- [ ] `dotnet build` succeeds
- [ ] Confirm the README permission table renders correctly
- [ ] Confirm the produced `.nupkg` reports the GPL-3.0-only licence