### PR TITLE
fix: CVE checks really disabled by default (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ---
 
+## [2.2.3] — 2026-05-13
+
+### Fixes
+
+- CVE checks are now really disabled by default (#34) — no more unexpected calls to `services.nvd.nist.gov` and `security-tracker.debian.org` unless you enable them in `settings.json`.
+- More reliable detection of TPM 2.0 on Windows 11 VMs.
+
+### Dependencies
+
+- Updated Corsinvest API packages to 9.1.17.
+
+
 ## [2.2.2] — 2026-04-18
 
 ### Documentation

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <PackageOutputPath>..\nupkgs\</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.13" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.17" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.17" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
@@ -385,7 +385,7 @@ public partial class DiagnosticEngine
                         });
                     }
 
-                    if (string.IsNullOrWhiteSpace(qemuConfig.Tpmstate0))
+                    if (qemuConfig.GetDisk("tpmstate0") is null)
                     {
                         _result.Add(new DiagnosticResult
                         {

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
@@ -15,14 +15,14 @@ public class SettingsCve
     /// Downloads CVE data for all Debian packages installed on each node.
     /// Covers system packages (kernel, qemu, lxc, openssl, ...).
     /// </summary>
-    public bool DebianTrackerEnabled { get; set; } = true;
+    public bool DebianTrackerEnabled { get; set; }
 
     /// <summary>
     /// Enable NVD checks for Proxmox-specific CVE.
     /// Queries NVD API once with keywordSearch=proxmox to find CVE affecting PVE directly.
     /// Optional API key speeds up the request (free at https://nvd.nist.gov/developers/request-an-api-key).
     /// </summary>
-    public bool NvdEnabled { get; set; } = true;
+    public bool NvdEnabled { get; set; }
 
     /// <summary>
     /// Minimum CVSS v3 base score to report (0.0–10.0).


### PR DESCRIPTION
## Summary

Closes #34.

- **CVE checks default fix**: `SettingsCve.DebianTrackerEnabled` and `NvdEnabled` defaulted to `true` in code, contradicting the README and the v2.2.0 changelog ("Both checks are **disabled by default**"). Reported by @crowtrobot: a fresh install triggered firewall alerts about connections to `services.nvd.nist.gov` and `security-tracker.debian.org`. Defaults are now `false` — users must opt in via `settings.json`.
- **Windows 11 TPM 2.0 check (WG0011)**: detect the TPM state disk via `GetDisk("tpmstate0")` instead of the raw `Tpmstate0` property — more reliable.
- **Dependencies**: bumped `Corsinvest.ProxmoxVE.Api.Extension` and `Corsinvest.ProxmoxVE.Api.Console` from 9.1.13 to 9.1.17.
- **Version**: 2.2.3.

## Test plan

- [ ] Run cv4pve-diag against a cluster without `settings.json` and confirm no requests go to `services.nvd.nist.gov` or `security-tracker.debian.org`.
- [ ] Run with `Cve.DebianTrackerEnabled=true` / `NvdEnabled=true` and confirm CVE checks still work.
- [ ] Verify `WG0011` triggers on a Windows 11 VM without TPM and not on one with TPM.