### PR TITLE
fix(IC0001): skip compression check for PBS backup jobs

### DIFF
--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
@@ -54,8 +54,12 @@ public partial class DiagnosticEngine
             return;
         }
 
-        // Backup jobs without compression waste storage space (zstd recommended)
-        _result.AddRange(backupList.Where(a => a.Enabled && string.IsNullOrWhiteSpace(a.Compress))
+        // Backup jobs without compression waste storage space (zstd recommended).
+        // PBS targets are skipped: Proxmox Backup Server compresses chunks server-side
+        // (always zstd) and exposes no 'compress' option on the job.
+        _result.AddRange(backupList.Where(a => a.Enabled
+                                               && string.IsNullOrWhiteSpace(a.Compress)
+                                               && !IsPbsStorage(a.Storage))
                                    .Select(a => new DiagnosticResult
                                    {
                                        Id = $"cluster/backup/{a.Id}",

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
@@ -11,11 +11,20 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 
 public partial class DiagnosticEngine
 {
+    private const string StoragePluginPbs = "pbs";
+
     private static readonly HashSet<string> _thinProvisioningTypes = new(StringComparer.OrdinalIgnoreCase)
         { "lvmthin", "zfspool", "rbd", "cephfs" };
 
     private static readonly HashSet<string> _sharedStorageTypes = new(StringComparer.OrdinalIgnoreCase)
         { "nfs", "cifs", "cephfs", "rbd", "iscsi", "iscsidirect", "glusterfs" };
+
+    private static bool IsPbsPluginType(string pluginType)
+        => string.Equals(pluginType, StoragePluginPbs, StringComparison.OrdinalIgnoreCase);
+
+    private bool IsPbsStorage(string storageName)
+        => !string.IsNullOrWhiteSpace(storageName)
+           && _storageResources.Any(s => s.Storage == storageName && IsPbsPluginType(s.PluginType));
 
     private record StorageContent(string Id,
                                   string Volume,


### PR DESCRIPTION
## Summary
Proxmox Backup Server compresses chunks server-side (always zstd) and exposes no `compress` option on the backup job. The lack of `compress=` on a PBS-targeted job is by design — flagging it produced noise that users could not silence except by disabling the check.

IC0001 now skips backup jobs whose destination storage has `pluginType == "pbs"`.

Added two helpers in `DiagnosticEngine.Storage` so future checks can reuse them:
- `IsPbsPluginType(pluginType)` — pure check on a plugin type string
- `IsPbsStorage(storageName)` — lookup by storage name against `_storageResources`

Fixes #39

## Test plan
- [ ] Cluster with a PBS-targeted backup job and no `compress` set — IC0001 no longer fires.
- [ ] Cluster with a non-PBS backup job and no `compress` set — IC0001 still fires.
- [ ] Cluster with a PBS-targeted backup job that has `compress=zstd` (unusual but possible) — still no IC0001.