### PR TITLE
fix: stop false positives for cloud-init / CD-ROM drives

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <PackageOutputPath>..\nupkgs\</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.17" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.17" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.18" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.18" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
@@ -100,23 +100,29 @@ public partial class DiagnosticEngine
             }
         }
 
-        // Remove volumes that are actually attached to a VM/LXC disk
-        // At the same time accumulate allocated disk size per storage for thin provisioning check
+        // Remove volumes that are actually attached to a VM/LXC — match against ALL
+        // volume entries (data disks + CD-ROM + cloud-init) so e.g. vm-NNN-cloudinit
+        // is not reported as orphaned (WS0002).
+        // Separately, accumulate allocated disk size per storage for the thin provisioning
+        // check — only real data disks count, CD-ROM/cloud-init are not provisioned.
         var allocatedByStorage = new Dictionary<string, long>(StringComparer.OrdinalIgnoreCase);
         foreach (var item in _resources.Where(a => a.ResourceType == ClusterResourceType.Vm))
         {
             var config = _vmConfigs[item.VmId];
 
-            foreach (var disk in config.Disks)
+            foreach (var disk in config.DisksAll)
             {
                 storagesImages.RemoveAll(a => a.VmId == item.VmId
                                               && a.Storage == disk.Storage
                                               && a.FileName == disk.FileName);
+            }
 
-                // Parse PVE disk size string (e.g. "32G", "500M") to bytes
-                // Exclude LXC mount points (mp*): they may be bind mounts reporting
-                // the full device/pool capacity rather than thin-allocated size.
-                // Only count volumes with no explicit MountPoint (QEMU disks, LXC rootfs).
+            // Parse PVE disk size string (e.g. "32G", "500M") to bytes.
+            // Exclude LXC mount points (mp*): they may be bind mounts reporting
+            // the full device/pool capacity rather than thin-allocated size.
+            // Only count volumes with no explicit MountPoint (QEMU disks, LXC rootfs).
+            foreach (var disk in config.Disks)
+            {
                 if (string.IsNullOrWhiteSpace(disk.MountPoint)
                     && !string.IsNullOrWhiteSpace(disk.Storage)
                     && !string.IsNullOrWhiteSpace(disk.Size))

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
@@ -200,22 +200,21 @@ public partial class DiagnosticEngine
 
 
             #region Cdrom
-            // A mounted ISO left in the drive is harmless but wastes storage and may confuse OS reinstalls
-            foreach (var value in config.ExtensionData.Values.Where(a => a != null).Select(a => a.ToString()!))
-            {
-                if (value.Contains("media=cdrom") && value != "none,media=cdrom")
-                {
-                    _result.Add(new DiagnosticResult
-                    {
-                        Id = id,
-                        ErrorCode = "WG0005",
-                        Description = "Cdrom mounted",
-                        Context = DiagnosticResultContext.Qemu,
-                        SubContext = "Hardware",
-                        Gravity = DiagnosticResultGravity.Warning,
-                    });
-                }
-            }
+            // A mounted ISO left in the drive is harmless but wastes storage and may confuse OS reinstalls.
+            // Cloud-init drives are excluded (Kind == CloudInit) — they always look like a cdrom but are
+            // legitimate and would otherwise generate a noisy false positive.
+            // Empty drives (Storage "none") are also skipped.
+            _result.AddRange(config.DisksAll
+                                   .Where(d => d.Kind == VmDiskKind.Cdrom && d.Storage != "none")
+                                   .Select(cdrom => new DiagnosticResult
+                                   {
+                                       Id = id,
+                                       ErrorCode = "WG0005",
+                                       Description = $"Cdrom mounted on '{cdrom.Id}' ({cdrom.Storage}:{cdrom.FileName})",
+                                       Context = DiagnosticResultContext.Qemu,
+                                       SubContext = "Hardware",
+                                       Gravity = DiagnosticResultGravity.Warning,
+                                   }));
             #endregion
 
             #region CPU Type


### PR DESCRIPTION
## Summary
Two checks misfired on VMs with a cloud-init drive (auto-created by Proxmox with `media=cdrom` and filename `vm-{vmid}-cloudinit`):

- **WS0002 "Image orphaned"** — the orphan match iterated `config.Disks`, which excluded CD-ROM entries — so the cloud-init image on storage was never paired with its VM and was reported as orphaned. Now the match uses `config.DisksAll` (data disks + CD-ROM + cloud-init).
- **WG0005 "CD-ROM mounted"** — the check scanned raw `ExtensionData` for `media=cdrom`, flagging every cloud-init drive. Now it iterates `config.DisksAll.Where(Kind == Cdrom)`, so cloud-init drives (`Kind == CloudInit`) are skipped. Description enriched with the drive id and `storage:filename` for easier triage.

The thin-provisioning accumulation in `DiagnosticEngine.Storage` stays on `config.Disks` (CD-ROM and cloud-init are not provisioned).

The SDK bump to 9.1.18 brings in `VmConfig.DisksAll` / `VmDisk.Kind`, **and also picks up the upstream fix for LXC rootfs backup defaults** (Corsinvest/cv4pve-api-dotnet#80), which closes #37.

Fixes #38
Fixes #37

## Test plan
- [ ] VM with cloud-init drive: WS0002 no longer fires on `vm-NNN-cloudinit`, WG0005 no longer fires on `ide0` cloud-init.
- [ ] VM with mounted ISO (e.g. `ide2: local-iso:iso/debian.iso,media=cdrom`): WG0005 still fires.
- [ ] VM with empty CD-ROM drive (`ide2: none,media=cdrom`): WG0005 does NOT fire.
- [ ] LXC container with rootfs and no explicit `backup=` flag: CG0002 no longer fires (#37).
- [ ] Thin overcommit (WS0004) unchanged — only real data disks are counted.