### PR TITLE
chore: release 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ---
 
+## [2.2.4] — 2026-05-14
+
+### Fixes
+
+- `WS0002` (Image Orphaned) — cloud-init drives (`vm-{vmid}-cloudinit`) and mounted ISOs are recognised as in-use and no longer reported as orphaned. Thin provisioning calculations are unchanged: they still consider only real data disks. (#38)
+- `WG0005` (Cdrom mounted) — cloud-init drives are no longer flagged. Real ISO mounts are still reported, with the drive id and `storage:filename` in the description for easier triage. (#38)
+- `CG0002` (Disk disabled for backup) — LXC `rootfs` is no longer flagged when no `backup=` flag is set. The parser now matches Proxmox defaults: Qemu disks included unless `backup=0`, LXC `rootfs` always included, LXC `mp*` excluded unless `backup=1`. (#37)
+- `IC0001` (Backup job no compression) — backup jobs targeting Proxmox Backup Server are no longer flagged. PBS handles compression server-side and exposes no `compress` option on the job. (#39)
+
+### Dependencies
+
+- Updated Corsinvest API packages to `9.1.18`.
+
+
 ## [2.2.3] — 2026-05-13
 
 ### Fixes

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.2.3</Version>
+    <Version>2.2.4</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Release 2.2.4 — bundles fixes for #37, #38, #39 already merged on `master`.

## Summary
- Bump `Version` 2.2.3 → 2.2.4.
- CHANGELOG entry for 2.2.4.

## Test plan
- [ ] Build runs clean.
- [ ] CHANGELOG renders correctly on GitHub.