### PR TITLE
feat: add cluster/node/storage diagnostic checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | No quorum                           | CC0001 | Quorum      | Critical | Cluster has lost quorum — VM operations may be blocked                   |
 | Corosync expected_votes mismatch    | CC0002 | Quorum      | Critical | Corosync expected votes does not match online node count                 |
 | HA group with offline nodes         | CC0003 | HA          | Critical | HA group references nodes that are currently offline                     |
+| HA resource in error state          | CC0005 | HA          | Critical | HA service is in error state — manual recovery required                  |
 | No HA resources configured          | IC0002 | HA          | Info     | No VMs/CTs protected by HA — no automatic failover on node failure       |
 | No replication jobs configured      | IC0003 | Replication | Info     | No storage replication configured — no redundant copy across nodes       |
+| Replication job disabled            | WC0009 | Replication | Warning  | Replication job is disabled — guest data is no longer replicated         |
+| Replication job no schedule         | WC0010 | Replication | Warning  | Enabled replication job has no schedule — it will never run              |
 | Pool empty                          | IC0004 | Pool        | Info     | Resource pool exists but has no VMs or storage assigned                  |
 | Cluster firewall disabled           | WC0003 | Firewall    | Warning  | Cluster-level firewall is completely disabled                            |
 | Firewall policy not DROP            | WC0004 | Firewall    | Warning  | Inbound or outbound policy allows unmatched traffic through              |
@@ -168,7 +171,12 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | Overly broad permissions            | WC0005 | Access      | Warning  | User has Administrator role at root path `/` — prefer scoped permissions |
 | Disabled user with active API token | WC0006 | Access      | Warning  | Disabled user still has valid API tokens that should be revoked          |
 | Local user no expiration            | IC0005 | Access      | Info     | Local user has no expiration date configured                             |
-| API token no expiration             | IC0006 | Access      | Info     | API token has no expiration date configured                              |
+| API token no expiration             | IC0006 | Access      | Info     | API token has no expiration date configured                             |
+| User without email                  | IC0007 | Access      | Info     | Enabled user has no email — will not receive notifications               |
+| Empty group                         | IC0008 | Access      | Info     | Group has no members                                                     |
+| Unused custom role                  | IC0009 | Access      | Info     | Custom role is not assigned in any ACL                                   |
+| Nodes PVE version mismatch          | WC0011 | Version     | Warning  | Online nodes run different Proxmox VE versions                           |
+| Nodes kernel mismatch               | WC0012 | Version     | Warning  | Online nodes run different kernel versions                               |
 
 </details>
 
@@ -187,9 +195,12 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | Nodes APT repos not equal          | WN0008        | AptRepositories  | Warning          | APT repository sources differ between nodes                                    |
 | NIC MTU mismatch                   | WN0009        | Network          | Warning          | Physical NIC MTU differs between nodes                                         |
 | NIC not active                     | WN0010        | Network          | Warning          | Physical NIC is down                                                           |
+| Bond without redundancy            | WN0034        | Network          | Warning          | Bond has fewer than two slaves — no link redundancy                            |
 | Package versions not equal         | CN0002        | PackageVersions  | Critical         | Nodes have different package versions installed                                |
 | Service not running                | WN0011        | Service          | Warning          | A required system service is not running                                       |
 | Certificate expired                | CN0003        | Certificates     | Critical         | TLS certificate has expired                                                    |
+| Certificate expiring soon          | WN0023        | Certificates     | Warning          | TLS certificate expires within 30 days                                         |
+| Certificate self-signed            | IN0004        | Certificates     | Info             | TLS certificate is self-signed — consider a CA-signed certificate              |
 | Replication errors                 | CN0004        | Replication      | Critical         | Replication job has errors                                                     |
 | Updates available                  | IN0001        | Update           | Info             | Packages available for update                                                  |
 | Important updates available        | WN0012        | Update           | Warning          | Security/important packages available for update                               |
@@ -237,7 +248,8 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 
 | Check                                | Code   | SubContext | Gravity          | Description                                                                         |
 | ------------------------------------ | ------ | ---------- | ---------------- | ----------------------------------------------------------------------------------- |
-| Storage unavailable                  | CS0001 | Status     | Critical         | Storage is not accessible                                                           |
+| Storage unavailable                  | CS0001 | Status     | Critical         | Storage is not accessible (excludes storages disabled on purpose)                   |
+| Storage disabled                     | WS0008 | Status     | Warning          | Storage is disabled — backup jobs or guests may still point at it                   |
 | Storage usage above threshold        | WS0001 | Usage      | Warning/Critical | Storage usage above configured threshold                                            |
 | Orphaned backup                      | WS0003 | Backup     | Warning          | Backup file whose VMID no longer exists                                             |
 | Orphaned disk image                  | WS0002 | Image      | Warning          | Disk image not attached to any VM/CT                                                |

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
@@ -89,8 +89,9 @@ public partial class DiagnosticEngine
     {
         // Cluster without any HA resource configured — no automatic failover on node failure
         var haResourcesTask = client.Cluster.Ha.Resources.GetAsync();
+        var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync();
         var replJobsTask = client.Cluster.Replication.GetAsync();
-        await Task.WhenAll(haResourcesTask, replJobsTask);
+        await Task.WhenAll(haResourcesTask, haStatusTask, replJobsTask);
 
         if (!haResourcesTask.Result.Any())
         {
@@ -105,6 +106,21 @@ public partial class DiagnosticEngine
             });
         }
 
+        // HA service in error state — the resource is not running and will not be recovered automatically
+        _result.AddRange(haStatusTask.Result
+                            .Where(a => a.Type == "service"
+                                        && !string.IsNullOrWhiteSpace(a.State)
+                                        && a.State.Equals("error", StringComparison.OrdinalIgnoreCase))
+                            .Select(a => new DiagnosticResult
+                            {
+                                Id = $"cluster/ha/{a.Sid}",
+                                ErrorCode = "CC0005",
+                                Description = $"HA resource '{a.Sid}' is in error state on node '{a.Node}' — manual recovery required",
+                                Context = DiagnosticResultContext.Cluster,
+                                SubContext = "HA",
+                                Gravity = DiagnosticResultGravity.Critical,
+                            }));
+
         // Cluster without any replication job — no storage redundancy between nodes
         if (!replJobsTask.Result.Any())
         {
@@ -118,6 +134,30 @@ public partial class DiagnosticEngine
                 Gravity = DiagnosticResultGravity.Info,
             });
         }
+
+        // Disabled replication job — the guest's data is no longer kept in sync on the target node
+        _result.AddRange(replJobsTask.Result.Where(a => a.Disable)
+                                            .Select(a => new DiagnosticResult
+                                            {
+                                                Id = $"cluster/replication/{a.Id}",
+                                                ErrorCode = "WC0009",
+                                                Description = $"Replication job '{a.Id}' (guest {a.Guest} → {a.Target}) is disabled — data is no longer replicated",
+                                                Context = DiagnosticResultContext.Cluster,
+                                                SubContext = "Replication",
+                                                Gravity = DiagnosticResultGravity.Warning,
+                                            }));
+
+        // Enabled replication job without a schedule — it will never run automatically
+        _result.AddRange(replJobsTask.Result.Where(a => !a.Disable && string.IsNullOrWhiteSpace(a.Schedule))
+                                            .Select(a => new DiagnosticResult
+                                            {
+                                                Id = $"cluster/replication/{a.Id}",
+                                                ErrorCode = "WC0010",
+                                                Description = $"Replication job '{a.Id}' (guest {a.Guest} → {a.Target}) has no schedule — it will never run automatically",
+                                                Context = DiagnosticResultContext.Cluster,
+                                                SubContext = "Replication",
+                                                Gravity = DiagnosticResultGravity.Warning,
+                                            }));
     }
 
     private async Task CheckClusterQuorumAndHaAsync(IEnumerable<ClusterStatus> clusterStatus,
@@ -280,10 +320,14 @@ public partial class DiagnosticEngine
         var accessUsersTask = client.Access.Users.GetAsync();
         var tfaEntriesTask = client.Access.Tfa.GetAsync();
         var aclsTask = client.Access.Acl.GetAsync();
-        await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask);
+        var groupsTask = client.Access.Groups.GetAsync();
+        var rolesTask = client.Access.Roles.GetAsync();
+        await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask, groupsTask, rolesTask);
         var accessUsers = accessUsersTask.Result;
         var tfaEntries = tfaEntriesTask.Result;
         var acls = aclsTask.Result;
+        var groups = groupsTask.Result;
+        var roles = rolesTask.Result;
 
         var usersWithTfa = tfaEntries.Where(t => t.Entries?.Any() is true)
                                      .Select(t => t.UserId)
@@ -376,5 +420,44 @@ public partial class DiagnosticEngine
                                             Gravity = DiagnosticResultGravity.Info,
                                         }));
         }
+
+        // Enabled users without an email — notifications (backup failures, fencing, etc.) cannot reach them
+        _result.AddRange(accessUsers.Where(a => a.Enable && string.IsNullOrWhiteSpace(a.Email))
+                                    .Select(a => new DiagnosticResult
+                                    {
+                                        Id = $"access/users/{a.Id}",
+                                        ErrorCode = "IC0007",
+                                        Description = $"User '{a.Id}' has no email configured — will not receive notifications",
+                                        Context = DiagnosticResultContext.Cluster,
+                                        SubContext = "Access",
+                                        Gravity = DiagnosticResultGravity.Info,
+                                    }));
+
+        // Empty groups — no users assigned, usually leftover configuration
+        _result.AddRange(groups.Where(a => string.IsNullOrWhiteSpace(a.Users))
+                               .Select(a => new DiagnosticResult
+                               {
+                                   Id = $"access/groups/{a.Id}",
+                                   ErrorCode = "IC0008",
+                                   Description = $"Group '{a.Id}' has no members",
+                                   Context = DiagnosticResultContext.Cluster,
+                                   SubContext = "Access",
+                                   Gravity = DiagnosticResultGravity.Info,
+                               }));
+
+        // Custom roles not referenced by any ACL — dead configuration
+        var rolesInUse = acls.Where(a => !string.IsNullOrWhiteSpace(a.Roleid))
+                             .Select(a => a.Roleid)
+                             .ToHashSet();
+        _result.AddRange(roles.Where(a => a.Special == 0 && !rolesInUse.Contains(a.Id))
+                              .Select(a => new DiagnosticResult
+                              {
+                                  Id = $"access/roles/{a.Id}",
+                                  ErrorCode = "IC0009",
+                                  Description = $"Custom role '{a.Id}' is not assigned in any ACL — unused",
+                                  Context = DiagnosticResultContext.Cluster,
+                                  SubContext = "Access",
+                                  Gravity = DiagnosticResultGravity.Info,
+                              }));
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
@@ -13,6 +13,9 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 
 public partial class DiagnosticEngine
 {
+    // Warn when a node TLS certificate expires within this many days.
+    private const int CertificateExpiringDays = 30;
+
     private static readonly Dictionary<int, DateTime> _pveEndOfLife = new()
     {
         { 8, new DateTime(2026, 08, 31) },
@@ -110,6 +113,48 @@ public partial class DiagnosticEngine
         // Pre-fetch all per-node data in parallel (subscription, services, certs, replication, apt, pci, tasks, disks)
         var nodeFetchResults = await RunParallelAsync(onlineNodes, FetchNodeDataAsync);
         var nodeFetchData = nodeFetchResults.ToDictionary(r => r.Item.Node, r => r);
+
+        #region Cluster-wide version / kernel consistency
+        // Compared once across all online nodes (not per node) — mixed versions/kernels after a partial upgrade
+        if (hasCluster && nodeCompareData.Count > 1)
+        {
+            var pveVersions = nodeCompareData.Values
+                                             .Select(a => a.Version.Version)
+                                             .Where(a => !string.IsNullOrWhiteSpace(a))
+                                             .Distinct()
+                                             .ToList();
+            if (pveVersions.Count > 1)
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = "cluster",
+                    ErrorCode = "WC0011",
+                    Description = $"Nodes run different Proxmox VE versions: {string.Join(", ", pveVersions)}",
+                    Context = DiagnosticResultContext.Cluster,
+                    SubContext = "Version",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
+            }
+
+            var kernels = nodeCompareData.Values
+                                         .Select(a => a.Status?.CurrentKernel?.Release)
+                                         .Where(a => !string.IsNullOrWhiteSpace(a))
+                                         .Distinct()
+                                         .ToList();
+            if (kernels.Count > 1)
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = "cluster",
+                    ErrorCode = "WC0012",
+                    Description = $"Nodes run different kernel versions: {string.Join(", ", kernels)}",
+                    Context = DiagnosticResultContext.Cluster,
+                    SubContext = "Version",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
+            }
+        }
+        #endregion
 
         foreach (var item in _resources.Where(a => a.ResourceType == ClusterResourceType.Node))
         {
@@ -315,6 +360,20 @@ public partial class DiagnosticEngine
                                          SubContext = "Network",
                                          Gravity = DiagnosticResultGravity.Warning,
                                      }));
+
+            // Bond with fewer than two slaves provides no link redundancy — a single NIC/cable failure takes it down
+            _result.AddRange(networks.Where(a => a.Type == "bond")
+                                     .Where(a => (a.Slaves ?? string.Empty)
+                                                    .Split(' ', StringSplitOptions.RemoveEmptyEntries).Length < 2)
+                                     .Select(a => new DiagnosticResult
+                                     {
+                                         Id = id,
+                                         ErrorCode = "WN0034",
+                                         Description = $"Bond '{a.Interface}' has fewer than two slaves — no link redundancy",
+                                         Context = DiagnosticResultContext.Node,
+                                         SubContext = "Network",
+                                         Gravity = DiagnosticResultGravity.Warning,
+                                     }));
             #endregion
 
             #region Package Versions
@@ -378,6 +437,38 @@ public partial class DiagnosticEngine
                                   Context = DiagnosticResultContext.Node,
                                   SubContext = "Certificates",
                                   Gravity = DiagnosticResultGravity.Critical,
+                              }));
+
+            // Certificates expiring within the warning window — renew before they break access
+            var certExpiryLimit = _now.AddDays(CertificateExpiringDays);
+            _result.AddRange(fetch.Certificates
+                              .Where(a =>
+                              {
+                                  var notAfter = DateTimeOffset.FromUnixTimeSeconds(a.NotAfter);
+                                  return notAfter >= _now && notAfter < certExpiryLimit;
+                              })
+                              .Select(a => new DiagnosticResult
+                              {
+                                  Id = id,
+                                  ErrorCode = "WN0023",
+                                  Description = $"Certificate '{a.FileName}' expires on {DateTimeOffset.FromUnixTimeSeconds(a.NotAfter):yyyy-MM-dd} (within {CertificateExpiringDays} days)",
+                                  Context = DiagnosticResultContext.Node,
+                                  SubContext = "Certificates",
+                                  Gravity = DiagnosticResultGravity.Warning,
+                              }));
+
+            // Self-signed certificate (issuer == subject) — browsers and API clients will warn / refuse
+            _result.AddRange(fetch.Certificates
+                              .Where(a => !string.IsNullOrWhiteSpace(a.Issuer)
+                                          && a.Issuer == a.Subject)
+                              .Select(a => new DiagnosticResult
+                              {
+                                  Id = id,
+                                  ErrorCode = "IN0004",
+                                  Description = $"Certificate '{a.FileName}' is self-signed — consider a CA-signed certificate (e.g. ACME/Let's Encrypt)",
+                                  Context = DiagnosticResultContext.Node,
+                                  SubContext = "Certificates",
+                                  Gravity = DiagnosticResultGravity.Info,
                               }));
             #endregion
 

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Storage.cs
@@ -35,8 +35,23 @@ public partial class DiagnosticEngine
 
     private async Task CheckStorageAsync()
     {
-        // Storage not reachable from the node — VMs on that node cannot read/write
-        _result.AddRange(_storageResources.Where(a => !a.IsAvailable)
+        // Storage deliberately disabled by the admin — not a fault, but worth surfacing
+        // (backup jobs / guests may still point at it). Reported separately from a real outage below.
+        _result.AddRange(_storageResources.Where(a => string.Equals(a.Status, "disabled", StringComparison.OrdinalIgnoreCase))
+                                          .Select(a => new DiagnosticResult
+                                          {
+                                              Id = a.GetWebUrl(),
+                                              ErrorCode = "WS0008",
+                                              Description = $"Storage '{a.Storage}' is disabled",
+                                              Context = DiagnosticResultContext.Storage,
+                                              SubContext = "Status",
+                                              Gravity = DiagnosticResultGravity.Warning,
+                                          }));
+
+        // Storage not reachable from the node — VMs on that node cannot read/write.
+        // Excludes storages disabled on purpose (handled above) — those are not a fault.
+        _result.AddRange(_storageResources.Where(a => !a.IsAvailable
+                                                      && !string.Equals(a.Status, "disabled", StringComparison.OrdinalIgnoreCase))
                                           .Select(a => new DiagnosticResult
                                           {
                                               Id = a.GetWebUrl(),


### PR DESCRIPTION
## Summary
Adds 12 new diagnostic checks across cluster, node and storage. Most reuse data already fetched by the engine; only 3 new cluster-level API calls were added (HA status current, access groups, access roles).

### Cluster
| Code | Check | Gravity |
|------|-------|---------|
| `CC0005` | HA resource in error state | Critical |
| `WC0009` | Replication job disabled | Warning |
| `WC0010` | Enabled replication job without schedule | Warning |
| `WC0011` | Nodes run different PVE versions | Warning |
| `WC0012` | Nodes run different kernel versions | Warning |
| `IC0007` | User without email (no notifications) | Info |
| `IC0008` | Empty group | Info |
| `IC0009` | Unused custom role | Info |

### Node
| Code | Check | Gravity |
|------|-------|---------|
| `WN0023` | Certificate expiring within 30 days | Warning |
| `WN0034` | Bond with fewer than two slaves (no redundancy) | Warning |
| `IN0004` | Self-signed certificate | Info |

### Storage
| Code | Check | Gravity |
|------|-------|---------|
| `WS0008` | Storage disabled | Warning |
| `CS0001` | **Fix:** no longer fires for storages disabled on purpose (was a false Critical "not available") |

### Notes / out of scope
- Firewall output policy: already covered by `WC0004`.
- Node subscription expired: already covered by `WN0004`.
- Metric-server checks deferred — the SDK exposes the endpoint only as a raw `Result`, no typed model yet. Would add `ClusterMetricServer` to the SDK first to stay consistent with the rest of diag.

README check tables updated.

## Test plan
- [ ] Cluster with a disabled replication job → `WC0009`; enabled-but-no-schedule → `WC0010`.
- [ ] Mixed-version / mixed-kernel cluster → `WC0011` / `WC0012`.
- [ ] HA service in error state → `CC0005`.
- [ ] Self-signed and soon-to-expire node certificates → `IN0004` / `WN0023`.
- [ ] Bond with a single slave → `WN0034`.
- [ ] Storage set to disabled → `WS0008`, and confirm `CS0001` does NOT also fire for it.
- [ ] Users without email / empty groups / unused custom roles → `IC0007` / `IC0008` / `IC0009`.