### PR TITLE
feat: resilient API calls — a failing fetch no longer aborts the analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ---
 
+## [Unreleased]
+
+### Resilience
+
+- A failing PVE API call no longer aborts the whole analysis. Each call now degrades gracefully: the affected check is skipped and a Warning (`WG0042`, sub-context `ApiError`) is reported so it is clear the picture is incomplete. Endpoints not implemented on the running PVE version (HTTP 501) are skipped silently.
+
+### New checks
+
+**Cluster:**
+- `CC0005` — HA resource in error state (manual recovery required).
+- `WC0009` — replication job disabled (guest data no longer replicated).
+- `WC0010` — enabled replication job without a schedule (it will never run).
+- `WC0011` — nodes run different Proxmox VE versions.
+- `WC0012` — nodes run different kernel versions.
+- `IC0007` — user without an email (will not receive notifications).
+- `IC0008` — empty group.
+- `IC0009` — unused custom role (not assigned in any ACL).
+
+**Node:**
+- `WN0023` — certificate expiring within 30 days.
+- `WN0034` — bond with fewer than two slaves (no link redundancy).
+- `IN0004` — self-signed certificate.
+
+**Storage:**
+- `WS0008` — storage disabled.
+
+### Fixes
+
+- `CS0001` (Storage unavailable) no longer fires for storages disabled on purpose — those are reported as `WS0008` (Warning) instead of a false Critical.
+
+
 ## [2.2.4] — 2026-05-14
 
 ### Fixes

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
     <PackageOutputPath>..\nupkgs\</PackageOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.18" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.18" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.2.0" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.2.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
@@ -14,16 +14,19 @@ public partial class DiagnosticEngine
 {
     private record ContainerFetchData(ClusterResource Item,
                                       VmConfigLxc Config,
-                                      VmFirewallOptions Firewall,
-                                      IEnumerable<KeyValue> Pending,
-                                      IEnumerable<VmSnapshot> Snapshots);
+                                      VmFirewallOptions? Firewall,
+                                      IReadOnlyList<KeyValue> Pending,
+                                      IReadOnlyList<VmSnapshot> Snapshots);
 
     private async Task<ContainerFetchData> FetchContainerDataAsync(ClusterResource item)
     {
         var vmApi = client.Nodes[item.Node].Lxc[item.VmId];
-        var firewallTask = vmApi.Firewall.Options.GetAsync();
-        var pendingTask = vmApi.Pending.GetAsync();
-        var snapshotTask = settings.Snapshot.Enabled ? vmApi.Snapshot.GetAsync() : Task.FromResult<IEnumerable<VmSnapshot>>([]);
+        var id = item.GetWebUrl();
+        var firewallTask = vmApi.Firewall.Options.GetAsync().ToSafeSingle(_result, id, DiagnosticResultContext.Lxc, $"firewall options of CT {item.VmId}");
+        var pendingTask = vmApi.Pending.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Lxc, $"pending changes of CT {item.VmId}");
+        var snapshotTask = settings.Snapshot.Enabled
+                            ? vmApi.Snapshot.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Lxc, $"snapshots of CT {item.VmId}")
+                            : Task.FromResult<IReadOnlyList<VmSnapshot>>([]);
         await Task.WhenAll(firewallTask, pendingTask, snapshotTask);
         return new ContainerFetchData(item, (VmConfigLxc)_vmConfigs[item.VmId],
                                       firewallTask.Result, pendingTask.Result, snapshotTask.Result);
@@ -43,7 +46,8 @@ public partial class DiagnosticEngine
             var id = item.GetWebUrl();
 
             #region Firewall and IP filter
-            CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Lxc);
+            // Firewall is null when its fetch failed — the failure was already recorded, so skip.
+            if (fetch.Firewall != null) { CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Lxc); }
             #endregion
 
             if (lxcConfig is VmConfigLxc lxc)

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Node.cs
@@ -36,32 +36,37 @@ public partial class DiagnosticEngine
                                    IEnumerable<NodeNetwork> Networks);
 
     private record NodeFetchData(ClusterResource Item,
-                                 NodeSubscription Subscription,
-                                 IEnumerable<NodeService> Services,
-                                 IEnumerable<NodeCertificate> Certificates,
-                                 IEnumerable<NodeReplication> Replication,
-                                 IEnumerable<NodeAptUpdate> AptUpdate,
-                                 IEnumerable<NodeHardwarePci> PciDevices,
-                                 IEnumerable<NodeTask> Tasks,
-                                 IEnumerable<NodeDiskList> Disks,
-                                 IEnumerable<NodeDiskZfs> ZfsList,
-                                 IEnumerable<NodeDiskLvmThin> LvmThinList);
+                                 NodeSubscription? Subscription,
+                                 IReadOnlyList<NodeService> Services,
+                                 IReadOnlyList<NodeCertificate> Certificates,
+                                 IReadOnlyList<NodeReplication> Replication,
+                                 IReadOnlyList<NodeAptUpdate> AptUpdate,
+                                 IReadOnlyList<NodeHardwarePci> PciDevices,
+                                 IReadOnlyList<NodeTask> Tasks,
+                                 IReadOnlyList<NodeDiskList> Disks,
+                                 IReadOnlyList<NodeDiskZfs> ZfsList,
+                                 IReadOnlyList<NodeDiskLvmThin> LvmThinList);
 
     private async Task<NodeFetchData> FetchNodeDataAsync(ClusterResource item)
     {
         var api = client.Nodes[item.Node];
-        var subscriptionTask = api.Subscription.GetAsync();
-        var servicesTask = api.Services.GetAsync();
-        var certificatesTask = api.Certificates.Info.GetAsync();
-        var replicationTask = api.Replication.GetAsync();
-        var aptUpdateTask = api.Apt.Update.GetAsync();
-        var pciTask = api.Hardware.Pci.GetAsync();
-        var tasksTask = api.Tasks.GetAsync(errors: true, limit: 1000);
-        var disksListTask = api.Disks.List.GetAsync(include_partitions: false);
-        var zfsListTask = api.Disks.Zfs.GetAsync();
+        var id = item.GetWebUrl();
+        var node = item.Node;
+
+        // Each call is individually safe: a single failing endpoint degrades to an empty
+        // list / null and records a finding, without aborting the other node data.
+        var subscriptionTask = api.Subscription.GetAsync().ToSafeSingle(_result, id, DiagnosticResultContext.Node, $"subscription on node '{node}'");
+        var servicesTask = api.Services.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"services on node '{node}'");
+        var certificatesTask = api.Certificates.Info.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"certificates on node '{node}'");
+        var replicationTask = api.Replication.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"replication on node '{node}'");
+        var aptUpdateTask = api.Apt.Update.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"APT updates on node '{node}'");
+        var pciTask = api.Hardware.Pci.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"PCI devices on node '{node}'");
+        var tasksTask = api.Tasks.GetAsync(errors: true, limit: 1000).ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"task history on node '{node}'");
+        var disksListTask = api.Disks.List.GetAsync(include_partitions: false).ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"disks on node '{node}'");
+        var zfsListTask = api.Disks.Zfs.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"ZFS pools on node '{node}'");
         var lvmThinListTask = settings.Node.NodeStorage.LvmThinMetadata
-                                    ? api.Disks.Lvmthin.GetAsync()
-                                    : Task.FromResult<IEnumerable<NodeDiskLvmThin>>([]);
+                                    ? api.Disks.Lvmthin.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Node, $"LVM-thin metadata on node '{node}'")
+                                    : Task.FromResult<IReadOnlyList<NodeDiskLvmThin>>([]);
         await Task.WhenAll(subscriptionTask, servicesTask, certificatesTask, replicationTask,
                            aptUpdateTask, pciTask, tasksTask, disksListTask, zfsListTask, lvmThinListTask);
 
@@ -74,41 +79,64 @@ public partial class DiagnosticEngine
                                  pciTask.Result,
                                  tasksTask.Result,
                                  disksListTask.Result,
-                                 zfsListTask.Result ?? [],
-                                 lvmThinListTask.Result ?? []);
+                                 zfsListTask.Result,
+                                 lvmThinListTask.Result);
     }
 
     private async Task CheckNodesAsync(bool hasCluster)
     {
         var onlineNodes = _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline).ToList();
 
-        // Pre-fetch lightweight per-node data — nodes in parallel, 8 calls per node in parallel
+        // Pre-fetch lightweight per-node data — nodes in parallel, 8 calls per node in parallel.
+        // These are the node's foundational data (version, status, network, …) used together by
+        // most node checks. If any of them fails the whole node is skipped (with a finding) rather
+        // than carrying half-populated state into every downstream check.
         var nodeCompareResults = await RunParallelAsync(onlineNodes, async item =>
         {
-            var api = client.Nodes[item.Node];
-            var versionTask = api.Version.GetAsync();
-            var hostsTask = api.Hosts.GetEtcHosts();
-            var dnsTask = api.Dns.GetAsync();
-            var aptVersionsTask = api.Apt.Versions.GetAsync();
-            var statusTask = api.Status.GetAsync();
-            var aptRepositoriesTask = api.Apt.Repositories.GetAsync();
-            var networksTask = api.Network.GetAsync();
-            var timeTask = api.Time.Time();
-            await Task.WhenAll(versionTask, hostsTask, dnsTask, aptVersionsTask,
-                               statusTask, aptRepositoriesTask, networksTask, timeTask);
+            var id = item.GetWebUrl();
+            try
+            {
+                var api = client.Nodes[item.Node];
+                var versionTask = api.Version.GetAsync();
+                var hostsTask = api.Hosts.GetEtcHosts();
+                var dnsTask = api.Dns.GetAsync();
+                var aptVersionsTask = api.Apt.Versions.GetAsync();
+                var statusTask = api.Status.GetAsync();
+                var aptRepositoriesTask = api.Apt.Repositories.GetAsync();
+                var networksTask = api.Network.GetAsync();
+                var timeTask = api.Time.Time();
+                await Task.WhenAll(versionTask, hostsTask, dnsTask, aptVersionsTask,
+                                   statusTask, aptRepositoriesTask, networksTask, timeTask);
 
-            var timeRaw = timeTask.Result.ToData();
-            return (item.Node, Data: new NodeCompareData(versionTask.Result,
-                                                         ((string)hostsTask.Result.ToData().data).Split('\n'),
-                                                         dnsTask.Result,
-                                                         timeRaw.timezone as string ?? "",
-                                                         aptVersionsTask.Result,
-                                                         statusTask.Result,
-                                                         timeRaw.time is long t ? t : 0L,
-                                                         aptRepositoriesTask.Result,
-                                                         networksTask.Result));
+                var timeRaw = timeTask.Result.ToData();
+                return (item.Node, Data: (NodeCompareData?)new NodeCompareData(versionTask.Result,
+                                                             ((string)hostsTask.Result.ToData().data).Split('\n'),
+                                                             dnsTask.Result,
+                                                             timeRaw.timezone as string ?? "",
+                                                             aptVersionsTask.Result,
+                                                             statusTask.Result,
+                                                             timeRaw.time is long t ? t : 0L,
+                                                             aptRepositoriesTask.Result,
+                                                             networksTask.Result));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = id,
+                    ErrorCode = DiagnosticSafeExtensions.ApiErrorCode,
+                    Description = $"Unable to read node data for '{item.Node}': {(ex is PveResultException pex ? DiagnosticSafeExtensions.BuildApiErrorMessage(pex.Result) : ex.Message)}",
+                    Context = DiagnosticResultContext.Node,
+                    SubContext = "ApiError",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
+                return (item.Node, Data: (NodeCompareData?)null);
+            }
         });
-        var nodeCompareData = nodeCompareResults.ToDictionary(r => r.Node, r => r.Data);
+        // Nodes whose foundational data failed to load are dropped here (a finding was already
+        // recorded). Downstream checks index/iterate this dictionary, so it holds only good nodes.
+        var nodeCompareData = nodeCompareResults.Where(r => r.Data != null)
+                                                .ToDictionary(r => r.Node, r => r.Data!);
 
         // Pre-fetch all per-node data in parallel (subscription, services, certs, replication, apt, pci, tasks, disks)
         var nodeFetchResults = await RunParallelAsync(onlineNodes, FetchNodeDataAsync);
@@ -174,8 +202,11 @@ public partial class DiagnosticEngine
                 continue;
             }
 
+            // Node data failed to load — the failure was already recorded, skip this node.
+            if (!nodeCompareData.TryGetValue(item.Node, out var compareData)) { continue; }
+
             var nodeApi = client.Nodes[item.Node];
-            var (version, hosts, dns, timezone, aptVersions, nodeStatus, nodeUtcTime, aptRepositories, networks) = nodeCompareData[item.Node];
+            var (version, hosts, dns, timezone, aptVersions, nodeStatus, nodeUtcTime, aptRepositories, networks) = compareData;
             if (!int.TryParse(version.Version?.Split(".")[0], out var nodeVersion)) { continue; }
 
             #region End Of Life
@@ -197,8 +228,10 @@ public partial class DiagnosticEngine
             var fetch = nodeFetchData[item.Node];
 
             #region Subscription
-            // Without an active subscription the node uses the community repo and has no enterprise support
-            if (!fetch.Subscription.Status.Equals("active", StringComparison.CurrentCultureIgnoreCase))
+            // Without an active subscription the node uses the community repo and has no enterprise support.
+            // Subscription is null when its fetch failed — the failure was already recorded, so just skip.
+            if (fetch.Subscription != null
+                && !fetch.Subscription.Status.Equals("active", StringComparison.CurrentCultureIgnoreCase))
             {
                 _result.Add(new DiagnosticResult
                 {

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Safe.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Safe.cs
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Net;
+using Corsinvest.ProxmoxVE.Api;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
+
+/// <summary>
+/// Safe wrappers around SDK calls. Mirror cv4pve-report's <c>ToSafe*</c>: a failing PVE API
+/// call never aborts the analysis — it degrades to an empty list / default and records a
+/// Warning DiagnosticResult so the user knows the picture is incomplete. A 501 (endpoint not
+/// implemented on this PVE version) is silent — it is not a problem.
+/// </summary>
+internal static class DiagnosticSafeExtensions
+{
+    // ErrorCode used whenever a PVE API call fails during analysis.
+    public const string ApiErrorCode = "WG0042";
+
+    /// <summary>
+    /// Awaits an SDK call returning <c>IEnumerable&lt;T&gt;</c>. Returns an empty list on failure.
+    /// </summary>
+    public static async Task<IReadOnlyList<T>> ToSafeEnum<T>(this Task<IEnumerable<T>> task,
+                                                             List<DiagnosticResult> result,
+                                                             string id,
+                                                             DiagnosticResultContext context,
+                                                             string what)
+    {
+        try { return (await task)?.ToList() ?? []; }
+        catch (Exception ex) when (Record(ex, result, id, context, what)) { return []; }
+    }
+
+    /// <summary>
+    /// Single-object variant of <see cref="ToSafeEnum{T}"/>. Returns <c>default(T)</c> on failure.
+    /// </summary>
+    public static async Task<T?> ToSafeSingle<T>(this Task<T> task,
+                                                 List<DiagnosticResult> result,
+                                                 string id,
+                                                 DiagnosticResultContext context,
+                                                 string what)
+    {
+        try { return await task; }
+        catch (Exception ex) when (Record(ex, result, id, context, what)) { return default; }
+    }
+
+    // Exception filter: returns true (catch fires) for every failure we swallow, after recording
+    // a Warning. Returns false only for cancellation (let it bubble). 501 is swallowed silently.
+    private static bool Record(Exception ex, List<DiagnosticResult> result, string id, DiagnosticResultContext context, string what)
+    {
+        if (ex is OperationCanceledException) { return false; }
+
+        // Endpoint not implemented on this PVE version — expected, not a problem.
+        if (ex is PveResultException { Result.StatusCode: HttpStatusCode.NotImplemented }) { return true; }
+
+        var detail = ex is PveResultException pex ? BuildApiErrorMessage(pex.Result) : ex.Message;
+
+        result.Add(new DiagnosticResult
+        {
+            Id = id,
+            ErrorCode = ApiErrorCode,
+            Description = $"Unable to read {what}: {detail}",
+            Context = context,
+            SubContext = "ApiError",
+            Gravity = DiagnosticResultGravity.Warning,
+        });
+        return true;
+    }
+
+    // "<code> <reason> — <api error> — <METHOD> <path>" so a finding is self-contained.
+    public static string BuildApiErrorMessage(Result r)
+    {
+        var parts = new List<string> { $"{(int)r.StatusCode} {r.ReasonPhrase}" };
+        var apiError = r.GetError();
+        if (!string.IsNullOrWhiteSpace(apiError)) { parts.Add(apiError); }
+        if (!string.IsNullOrWhiteSpace(r.RequestResource)) { parts.Add($"{r.MethodType} {r.RequestResource}"); }
+        return string.Join(" — ", parts);
+    }
+}

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
@@ -28,18 +28,21 @@ public partial class DiagnosticEngine
 
     private record VmFetchData(ClusterResource Item,
                                VmConfigQemu Config,
-                               VmFirewallOptions Firewall,
-                               IEnumerable<KeyValue> Pending,
-                               IEnumerable<VmSnapshot> Snapshots,
+                               VmFirewallOptions? Firewall,
+                               IReadOnlyList<KeyValue> Pending,
+                               IReadOnlyList<VmSnapshot> Snapshots,
                                object? AgentInfo);
 
     private async Task<VmFetchData> FetchVmDataAsync(ClusterResource item)
     {
         var vmApi = client.Nodes[item.Node].Qemu[item.VmId];
+        var id = item.GetWebUrl();
         var config = (VmConfigQemu)_vmConfigs[item.VmId];
-        var firewallTask = vmApi.Firewall.Options.GetAsync();
-        var pendingTask = vmApi.Pending.GetAsync();
-        var snapshotTask = settings.Snapshot.Enabled ? vmApi.Snapshot.GetAsync() : Task.FromResult<IEnumerable<VmSnapshot>>([]);
+        var firewallTask = vmApi.Firewall.Options.GetAsync().ToSafeSingle(_result, id, DiagnosticResultContext.Qemu, $"firewall options of VM {item.VmId}");
+        var pendingTask = vmApi.Pending.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Qemu, $"pending changes of VM {item.VmId}");
+        var snapshotTask = settings.Snapshot.Enabled
+                            ? vmApi.Snapshot.GetAsync().ToSafeEnum(_result, id, DiagnosticResultContext.Qemu, $"snapshots of VM {item.VmId}")
+                            : Task.FromResult<IReadOnlyList<VmSnapshot>>([]);
         await Task.WhenAll(firewallTask, pendingTask, snapshotTask);
 
         object? agentInfo = null;
@@ -508,7 +511,8 @@ public partial class DiagnosticEngine
             #endregion
 
             #region Firewall and IP filter
-            CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Qemu);
+            // Firewall is null when its fetch failed — the failure was already recorded, so skip.
+            if (fetch.Firewall != null) { CheckVmFirewall(_result, fetch.Firewall, id, DiagnosticResultContext.Qemu); }
             #endregion
 
             #region USB/PCI passthrough

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
@@ -44,7 +44,27 @@ public partial class DiagnosticEngine(PveClient client, Settings settings, HttpC
 
         try
         {
-            var allResources = await client.Cluster.Resources.GetAsync();
+            IReadOnlyList<ClusterResource> allResources;
+            try
+            {
+                allResources = (await client.Cluster.Resources.GetAsync()).ToList();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // The foundational call failed — there is nothing to analyze. Report it as
+                // critical and return cleanly instead of letting the exception crash the run.
+                _result.Add(new DiagnosticResult
+                {
+                    Id = "cluster",
+                    ErrorCode = "CU0001",
+                    Description = $"Unable to read cluster resources: {(ex is PveResultException pex ? DiagnosticSafeExtensions.BuildApiErrorMessage(pex.Result) : ex.Message)}",
+                    Context = DiagnosticResultContext.Cluster,
+                    SubContext = "ApiError",
+                    Gravity = DiagnosticResultGravity.Critical,
+                });
+                return _result;
+            }
+
             _resources = [.. allResources.Where(a => !a.IsUnknown)];
 
             // Resources with unknown type are always a problem — report them all as Critical
@@ -85,18 +105,31 @@ public partial class DiagnosticEngine(PveClient client, Settings settings, HttpC
                                                                   node,
                                                                   storages = settings.Backup.Enabled
                                                                                 ? await client.Nodes[node].Storage.GetAsync(content: "backup", enabled: true)
-                                                                                : []
+                                                                                                     .ToSafeEnum(_result, $"nodes/{node}", DiagnosticResultContext.Node, $"backup storages on node '{node}'")
+                                                                                : (IReadOnlyList<NodeStorage>)[]
                                                               });
-            _backupStoragesByNode = backupStorageResults.ToDictionary(a => a.node, a => a.storages);
+            _backupStoragesByNode = backupStorageResults.ToDictionary(a => a.node, a => (IEnumerable<NodeStorage>)a.storages);
 
-            // Pre-fetch VM configs once — shared by CheckQemuAsync, CheckLxcAsync, CheckStorageAsync
+            // Pre-fetch VM configs once — shared by CheckQemuAsync, CheckLxcAsync, CheckStorageAsync.
+            // A guest whose config cannot be read is skipped (excluded from the dictionary) so the
+            // checks that index _vmConfigs[VmId] never hit a null — the failure is recorded instead.
             var vmConfigResults = await RunParallelAsync(_resources.Where(a => a.ResourceType == ClusterResourceType.Vm),
                                                          async vm => new
                                                          {
                                                              vm.VmId,
                                                              config = await client.GetVmConfigAsync(vm.Node, vm.VmType, vm.VmId)
+                                                                                  .ToSafeSingle(_result,
+                                                                                                vm.GetWebUrl(),
+                                                                                                DiagnosticResult.DecodeContext(vm.Type),
+                                                                                                $"configuration of {vm.Type} {vm.VmId}")
                                                          });
-            _vmConfigs = vmConfigResults.ToDictionary(r => r.VmId, r => r.config);
+            _vmConfigs = vmConfigResults.Where(r => r.config != null)
+                                        .ToDictionary(r => r.VmId, r => r.config!);
+
+            // Guests whose config failed to load are not present in _vmConfigs — skip them in the
+            // per-guest checks below instead of indexing a missing key.
+            _resources = [.. _resources.Where(a => a.ResourceType != ClusterResourceType.Vm
+                                                   || _vmConfigs.ContainsKey(a.VmId))];
 
             await CheckStorageAsync();
             await CheckNodesAsync(hasCluster);


### PR DESCRIPTION
## Summary
A single failing PVE API call used to throw out of the whole run, aborting the analysis. Now every call degrades gracefully — modelled on cv4pve-report's `ToSafe*` approach.

- New `DiagnosticEngine.Safe` with `ToSafeEnum` / `ToSafeSingle` extensions. On failure they return an empty list / default and record a Warning (`WG0042`, sub-context `ApiError`) so the user knows the picture is incomplete. HTTP 501 (endpoint not implemented on this PVE version) is swallowed silently; cancellation is left to bubble.
- `Cluster.Resources` (foundational call): on failure reports a Critical and returns cleanly instead of crashing.
- Per-guest config prefetch: a guest whose config can't be read is excluded from the analysis (with a finding) so per-guest checks never index a missing key.
- `FetchNodeDataAsync` / `FetchVmDataAsync` / `FetchContainerDataAsync`: each call is individually safe, with null-guards at the few single-object use sites (subscription, firewall).
- `nodeCompareData` (interdependent foundational node data): protected as a unit — if it fails the node is skipped with a finding rather than carrying half-populated state downstream.

Also bumps the SDK to 9.2.0.

CHANGELOG: `Unreleased` section covering resilience, the new checks already on master, and the `CS0001` false-positive fix.

## Test plan
- [ ] Revoke a permission so one endpoint returns 403 → analysis completes, a `WG0042` finding appears for that fetch, all other checks still run.
- [ ] Run against a PVE version missing an endpoint (501) → no `WG0042` noise for it.
- [ ] A VM whose config can't be read → excluded with a finding, other guests analysed normally.
- [ ] Happy path on a healthy cluster → no `WG0042` findings at all.