### PR TITLE
chore: release 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ---
 
-## [Unreleased]
+## [2.3.0] — 2026-05-27
 
 ### Resilience
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.2.4</Version>
+    <Version>2.3.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Release 2.3.0.

## Highlights
- **Resilience**: a failing PVE API call no longer aborts the analysis (`WG0042` findings, 501 silenced).
- **12 new checks** across Cluster, Node and Storage.
- **Fix**: `CS0001` no longer fires for storages disabled on purpose.

## Changes
- Bump `Version` 2.2.4 → 2.3.0.
- CHANGELOG `[Unreleased]` → `[2.3.0]`.

## Test plan
- [ ] Build runs clean.
- [ ] CHANGELOG renders correctly on GitHub.