### PR TITLE
feat: tighter CVE checks + xUnit test project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ---
 
+## [Unreleased]
+
+### CVE checks
+
+- `CN0014` / `WN0041` (Debian Security Tracker) — a CVE is no longer reported for a package that is already at or beyond the released fix. Removes most false positives on patched systems.
+- `CN0015` / `WN0042` (NVD) — the NVD query now targets Proxmox VE directly (CPE-based) instead of a generic keyword search, so no relevant historical CVE is missed and no unrelated product is reported.
+- Failures fetching CVE data now emit a `WG0042` warning instead of leaving the section silently empty.
+- CVE entries with no severity score or no description are skipped.
+
+
 ## [2.3.0] — 2026-05-27
 
 ### Resilience

--- a/Corsinvest.ProxmoxVE.Diagnostic.slnx
+++ b/Corsinvest.ProxmoxVE.Diagnostic.slnx
@@ -8,4 +8,7 @@
     <Project Path="src/Corsinvest.ProxmoxVE.Diagnostic.Api/Corsinvest.ProxmoxVE.Diagnostic.Api.csproj" />
     <Project Path="src/Corsinvest.ProxmoxVE.Diagnostic/Corsinvest.ProxmoxVE.Diagnostic.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,4 +8,9 @@
     <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.2.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
   </ItemGroup>
+  <ItemGroup Label="Test">
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Corsinvest.ProxmoxVE.Diagnostic.Api.csproj
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Corsinvest.ProxmoxVE.Diagnostic.Api.csproj
@@ -31,4 +31,8 @@
     <PackageReference Include="Corsinvest.ProxmoxVE.Api.Extension" />
     <!-- <ProjectReference Include="..\..\..\cv4pve-api-dotnet\src\Corsinvest.ProxmoxVE.Api.Extension\Corsinvest.ProxmoxVE.Api.Extension.csproj" /> -->
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Corsinvest.ProxmoxVE.Diagnostic.Api.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using Corsinvest.ProxmoxVE.Api.Shared.Models.Node;
+using Corsinvest.ProxmoxVE.Diagnostic.Api.Helpers;
 
 namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 
@@ -21,8 +22,9 @@ public partial class DiagnosticEngine
 
     private static readonly string[] _cvssMetricKeys = ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"];
 
-    // Debian Tracker: package → CVE → (status, urgency) — filtered to the detected release at parse time
-    private record DebianCveEntry(string Status, string Urgency);
+    // Debian Tracker: package → CVE → (status, urgency, fixed_version) — filtered to the detected release at parse time.
+    // FixedVersion is null when the tracker has no fix yet, "" when fixed in the base package, otherwise the version that closes the CVE.
+    private record DebianCveEntry(string Status, string Urgency, string? FixedVersion);
 
     // NVD CVE entry — only what we need
     private record NvdCveEntry(string Id,
@@ -42,156 +44,176 @@ public partial class DiagnosticEngine
         httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("cv4pve-diag/1.0");
 
         var tasks = new List<Task>();
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
 
-        if (settings.Cve.DebianTrackerEnabled)
-        {
-            tasks.Add(Task.Run(async () =>
-            {
-                try
-                {
-                    await using var stream = await httpClient.GetStreamAsync("https://security-tracker.debian.org/tracker/data/json", cts.Token);
-                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
-                    var result = new Dictionary<string, Dictionary<string, DebianCveEntry>>(StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var pkg in doc.RootElement.EnumerateObject())
-                    {
-                        var cveMap = new Dictionary<string, DebianCveEntry>(StringComparer.OrdinalIgnoreCase);
-                        foreach (var cve in pkg.Value.EnumerateObject())
-                        {
-                            if (!cve.Value.TryGetProperty("releases", out var releases)) { continue; }
-
-                            // Filter at parse time — keep only the detected Debian release
-                            if (!releases.TryGetProperty(debianRelease, out var rel)) { continue; }
-
-                            var status = rel.TryGetProperty("status", out var s) ? s.GetString() ?? "" : "";
-                            var urgency = rel.TryGetProperty("urgency", out var u) ? u.GetString() ?? "" : "";
-
-                            if (status != "open") { continue; }
-                            if (urgency is "unimportant" or "end-of-life") { continue; }
-
-                            cveMap[cve.Name] = new DebianCveEntry(status, urgency);
-                        }
-                        if (cveMap.Count > 0) { result[pkg.Name] = cveMap; }
-                    }
-                    _debianCveData = result;
-                }
-                catch { _debianCveData = []; }
-            }));
-        }
-
-        if (settings.Cve.NvdEnabled)
-        {
-            tasks.Add(Task.Run(async () =>
-            {
-                try
-                {
-                    await using var stream = await httpClient.GetStreamAsync("https://services.nvd.nist.gov/rest/json/cves/2.0?keywordSearch=proxmox&resultsPerPage=100", cts.Token);
-                    using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
-                    var result = new List<NvdCveEntry>();
-                    if (!doc.RootElement.TryGetProperty("vulnerabilities", out var vulns)) { return; }
-
-                    foreach (var vuln in vulns.EnumerateArray())
-                    {
-                        if (!vuln.TryGetProperty("cve", out var cve)) { continue; }
-                        var id = cve.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
-
-                        // Description (English only)
-                        var desc = "";
-                        if (cve.TryGetProperty("descriptions", out var descs))
-                        {
-                            foreach (var d in descs.EnumerateArray())
-                            {
-                                if (d.TryGetProperty("lang", out var lang) && lang.GetString() == "en")
-                                {
-                                    desc = d.TryGetProperty("value", out var v) ? v.GetString() ?? "" : "";
-                                    break;
-                                }
-                            }
-                        }
-
-                        // CVSS score — prefer v31, fallback v30, fallback v2
-                        double? score = null;
-                        string? severity = null;
-                        if (cve.TryGetProperty("metrics", out var metrics))
-                        {
-                            foreach (var metricKey in _cvssMetricKeys)
-                            {
-                                if (!metrics.TryGetProperty(metricKey, out var metricArr)) { continue; }
-                                foreach (var m in metricArr.EnumerateArray())
-                                {
-                                    if (!m.TryGetProperty("cvssData", out var cvssData)) { continue; }
-                                    if (cvssData.TryGetProperty("baseScore", out var bs)) { score = bs.GetDouble(); }
-                                    if (m.TryGetProperty("baseSeverity", out var sev)) { severity = sev.GetString(); }
-                                    else if (cvssData.TryGetProperty("baseSeverity", out var sev2)) { severity = sev2.GetString(); }
-                                    break;
-                                }
-                                if (score.HasValue) { break; }
-                            }
-                        }
-
-                        // Filter by MinCvssScore at parse time
-                        if (score < settings.Cve.MinCvssScore) { continue; }
-
-                        // Version range from CPE — first proxmox:virtual_environment entry
-                        string? versionStart = null, versionEnd = null;
-                        if (cve.TryGetProperty("configurations", out var configs))
-                        {
-                            foreach (var config in configs.EnumerateArray())
-                            {
-                                if (!config.TryGetProperty("nodes", out var nodes)) { continue; }
-                                foreach (var node in nodes.EnumerateArray())
-                                {
-                                    if (!node.TryGetProperty("cpeMatch", out var cpeMatches)) { continue; }
-                                    foreach (var cpe in cpeMatches.EnumerateArray())
-                                    {
-                                        if (!cpe.TryGetProperty("criteria", out var criteria)) { continue; }
-                                        if (!criteria.GetString()!.Contains("proxmox:virtual_environment", StringComparison.OrdinalIgnoreCase)) { continue; }
-                                        if (cpe.TryGetProperty("versionStartIncluding", out var vs)) { versionStart = vs.GetString(); }
-                                        if (cpe.TryGetProperty("versionEndExcluding", out var ve)) { versionEnd = ve.GetString(); }
-                                        else if (cpe.TryGetProperty("versionEndIncluding", out var vi)) { versionEnd = vi.GetString(); }
-                                        break;
-                                    }
-                                    if (versionStart != null || versionEnd != null) { break; }
-                                }
-                                if (versionStart != null || versionEnd != null) { break; }
-                            }
-                        }
-
-                        // Skip CVE with no CPE for proxmox:virtual_environment (Salt, Jenkins, Foreman, Terraform, etc.)
-                        if (versionStart == null && versionEnd == null) { continue; }
-
-                        // Skip CVE with no upper version bound — cannot determine if current version is affected
-                        if (string.IsNullOrWhiteSpace(versionEnd)) { continue; }
-
-                        result.Add(new NvdCveEntry(id, desc, score, severity, versionStart, versionEnd));
-                    }
-                    _nvdCveData = result;
-                }
-                catch { _nvdCveData = []; }
-            }));
-        }
+        if (settings.Cve.DebianTrackerEnabled) { tasks.Add(FetchDebianCveAsync(debianRelease)); }
+        if (settings.Cve.NvdEnabled) { tasks.Add(FetchNvdCveAsync()); }
 
         await Task.WhenAll(tasks);
     }
 
-    // Compare two version strings numerically segment by segment (e.g. "8.1.4" vs "7.2-3").
-    // Non-numeric segments are compared as strings. Returns negative if a < b, 0 if equal, positive if a > b.
-    private static int CompareVersions(string a, string b)
+    private async Task FetchDebianCveAsync(string debianRelease)
     {
-        var aParts = a.Split('.', '-');
-        var bParts = b.Split('.', '-');
-        var len = Math.Max(aParts.Length, bParts.Length);
-        for (var i = 0; i < len; i++)
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        try
         {
-            var aSeg = i < aParts.Length ? aParts[i] : "0";
-            var bSeg = i < bParts.Length ? bParts[i] : "0";
-            var cmp = int.TryParse(aSeg, out var aNum) && int.TryParse(bSeg, out var bNum)
-                        ? aNum.CompareTo(bNum)
-                        : string.Compare(aSeg, bSeg, StringComparison.OrdinalIgnoreCase);
-            if (cmp != 0) { return cmp; }
+            await using var stream = await httpClient.GetStreamAsync("https://security-tracker.debian.org/tracker/data/json", cts.Token);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
+            var result = new Dictionary<string, Dictionary<string, DebianCveEntry>>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var pkg in doc.RootElement.EnumerateObject())
+            {
+                var cveMap = new Dictionary<string, DebianCveEntry>(StringComparer.OrdinalIgnoreCase);
+                foreach (var cve in pkg.Value.EnumerateObject())
+                {
+                    if (!cve.Value.TryGetProperty("releases", out var releases)) { continue; }
+
+                    // Filter at parse time — keep only the detected Debian release
+                    if (!releases.TryGetProperty(debianRelease, out var rel)) { continue; }
+
+                    var status = rel.TryGetProperty("status", out var s) ? s.GetString() ?? "" : "";
+                    if (status != "open") { continue; }
+
+                    var urgency = rel.TryGetProperty("urgency", out var u) ? u.GetString() ?? "" : "";
+                    if (urgency is "unimportant" or "end-of-life") { continue; }
+
+                    var fixedVersion = rel.TryGetProperty("fixed_version", out var fv) ? fv.GetString() : null;
+
+                    cveMap[cve.Name] = new DebianCveEntry(status, urgency, fixedVersion);
+                }
+                if (cveMap.Count > 0) { result[pkg.Name] = cveMap; }
+            }
+            _debianCveData = result;
         }
-        return 0;
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Surface the failure as a finding instead of silently leaving the check empty —
+            // an empty result would otherwise read as "no CVEs found", giving a false sense of safety.
+            _debianCveData = [];
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster",
+                ErrorCode = DiagnosticSafeExtensions.ApiErrorCode,
+                Description = $"Unable to fetch Debian Security Tracker data: {ex.Message}",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "ApiError",
+                Gravity = DiagnosticResultGravity.Warning,
+            });
+        }
+    }
+
+    private async Task FetchNvdCveAsync()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+        try
+        {
+            // Query by CPE (vs free-text keywordSearch=proxmox) so the server returns only
+            // Proxmox VE entries — no Salt/Jenkins/Foreman/Terraform noise to filter out client-side.
+            // resultsPerPage=2000 is the NVD maximum and comfortably covers all historical PVE CVEs.
+            await using var stream = await httpClient.GetStreamAsync("https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=cpe:2.3:a:proxmox:virtual_environment:*&resultsPerPage=2000", cts.Token);
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
+            var result = new List<NvdCveEntry>();
+            if (!doc.RootElement.TryGetProperty("vulnerabilities", out var vulns)) { _nvdCveData = result; return; }
+
+            foreach (var vuln in vulns.EnumerateArray())
+            {
+                if (!vuln.TryGetProperty("cve", out var cve)) { continue; }
+                var id = cve.TryGetProperty("id", out var idEl) ? idEl.GetString() ?? "" : "";
+
+                var (score, severity) = ExtractCvss(cve);
+
+                // A CVE with no CVSS score cannot be ranked for severity — skip rather than
+                // emit an Info finding with no actionable information.
+                if (score is null || score < settings.Cve.MinCvssScore) { continue; }
+
+                var (versionStart, versionEnd) = ExtractProxmoxVersionRange(cve);
+
+                // Without an upper version bound we cannot tell whether the installed version is affected.
+                // This also drops CVEs where the CPE only references other products.
+                if (string.IsNullOrWhiteSpace(versionEnd)) { continue; }
+
+                var desc = ExtractEnglishDescription(cve);
+                // A finding without a description is noise — skip it.
+                if (string.IsNullOrWhiteSpace(desc)) { continue; }
+
+                result.Add(new NvdCveEntry(id, desc, score, severity, versionStart, versionEnd));
+            }
+            _nvdCveData = result;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _nvdCveData = [];
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster",
+                ErrorCode = DiagnosticSafeExtensions.ApiErrorCode,
+                Description = $"Unable to fetch NVD CVE data: {ex.Message}",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "ApiError",
+                Gravity = DiagnosticResultGravity.Warning,
+            });
+        }
+    }
+
+    // English description, or empty if not present.
+    private static string ExtractEnglishDescription(JsonElement cve)
+    {
+        if (!cve.TryGetProperty("descriptions", out var descs)) { return ""; }
+        foreach (var d in descs.EnumerateArray())
+        {
+            if (d.TryGetProperty("lang", out var lang) && lang.GetString() == "en")
+            {
+                return d.TryGetProperty("value", out var v) ? v.GetString() ?? "" : "";
+            }
+        }
+        return "";
+    }
+
+    // CVSS base score + severity. Preference order v3.1 → v3.0 → v2, mirroring NVD's own ordering.
+    private static (double? Score, string? Severity) ExtractCvss(JsonElement cve)
+    {
+        if (!cve.TryGetProperty("metrics", out var metrics)) { return (null, null); }
+
+        foreach (var metricKey in _cvssMetricKeys)
+        {
+            if (!metrics.TryGetProperty(metricKey, out var metricArr)) { continue; }
+            foreach (var m in metricArr.EnumerateArray())
+            {
+                if (!m.TryGetProperty("cvssData", out var cvssData)) { continue; }
+                double? score = cvssData.TryGetProperty("baseScore", out var bs) ? bs.GetDouble() : null;
+                var severity = cvssData.TryGetProperty("baseSeverity", out var sev) ? sev.GetString() : null;
+                if (score.HasValue) { return (score, severity); }
+            }
+        }
+        return (null, null);
+    }
+
+    // Pulls (versionStartIncluding, versionEndExcluding|versionEndIncluding) from the first
+    // CPE entry that references proxmox:virtual_environment. The CPE filter is still needed
+    // even with cpeName= on the request: a CVE may include CPEs for other products too, and
+    // we must take the range from the right one.
+    private static (string? Start, string? End) ExtractProxmoxVersionRange(JsonElement cve)
+    {
+        if (!cve.TryGetProperty("configurations", out var configs)) { return (null, null); }
+        foreach (var config in configs.EnumerateArray())
+        {
+            if (!config.TryGetProperty("nodes", out var nodes)) { continue; }
+            foreach (var node in nodes.EnumerateArray())
+            {
+                if (!node.TryGetProperty("cpeMatch", out var cpeMatches)) { continue; }
+                foreach (var cpe in cpeMatches.EnumerateArray())
+                {
+                    if (!cpe.TryGetProperty("criteria", out var criteria)) { continue; }
+                    if (!criteria.GetString()!.Contains("proxmox:virtual_environment", StringComparison.OrdinalIgnoreCase)) { continue; }
+
+                    var start = cpe.TryGetProperty("versionStartIncluding", out var vs) ? vs.GetString() : null;
+                    string? end = null;
+                    if (cpe.TryGetProperty("versionEndExcluding", out var ve)) { end = ve.GetString(); }
+                    else if (cpe.TryGetProperty("versionEndIncluding", out var vi)) { end = vi.GetString(); }
+                    return (start, end);
+                }
+            }
+        }
+        return (null, null);
     }
 
     private void CheckNodeCve(string id, IEnumerable<NodeAptVersion> aptVersions)
@@ -201,11 +223,19 @@ public partial class DiagnosticEngine
         {
             foreach (var pkg in aptVersions)
             {
-                if (string.IsNullOrWhiteSpace(pkg.Package)) { continue; }
+                if (string.IsNullOrWhiteSpace(pkg.Package) || string.IsNullOrWhiteSpace(pkg.Version)) { continue; }
                 if (!_debianCveData.TryGetValue(pkg.Package, out var cveMap)) { continue; }
 
                 foreach (var (cveId, entry) in cveMap)
                 {
+                    // The installed package may already be at or beyond the fixed version published
+                    // by Debian Security; in that case the CVE is closed for us, skip it.
+                    if (!string.IsNullOrWhiteSpace(entry.FixedVersion)
+                        && DebianVersion.Compare(pkg.Version, entry.FixedVersion) >= 0)
+                    {
+                        continue;
+                    }
+
                     var gravity = entry.Urgency switch
                     {
                         "high" => DiagnosticResultGravity.Critical,
@@ -238,7 +268,7 @@ public partial class DiagnosticEngine
                 // Skip if installed pve-manager version is beyond the vulnerable range
                 if (!string.IsNullOrWhiteSpace(pveVerStr) && !string.IsNullOrWhiteSpace(cve.VersionEnd))
                 {
-                    if (CompareVersions(pveVerStr, cve.VersionEnd) > 0) { continue; }
+                    if (DebianVersion.Compare(pveVerStr, cve.VersionEnd) > 0) { continue; }
                 }
 
                 var gravity = cve.CvssScore switch

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Helpers/DebianVersion.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/Helpers/DebianVersion.cs
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api.Helpers;
+
+/// <summary>
+/// Debian-style version comparison, equivalent to <c>dpkg --compare-versions</c>.
+/// Reference: <c>verrevcmp</c> in dpkg's <c>lib/dpkg/version.c</c>
+/// and <c>deb-version(7)</c>.
+///
+/// Format: <c>[epoch:]upstream-version[-debian-revision]</c>.
+/// Both upstream and revision are compared with the same algorithm:
+/// alternate non-digit and digit runs. In a non-digit run the character order is:
+/// <c>~</c> (sorts before everything, even end-of-string) &lt; end-of-string &lt; letters &lt; the rest.
+/// An absent debian-revision sorts before <c>"0"</c>.
+/// </summary>
+internal static class DebianVersion
+{
+    /// <summary>
+    /// Compares two Debian version strings. Returns a negative number if
+    /// <paramref name="a"/> &lt; <paramref name="b"/>, zero if equal, positive if greater.
+    /// Null or whitespace is treated as the lowest possible version.
+    /// </summary>
+    public static int Compare(string? a, string? b)
+    {
+        a = (a ?? "").Trim();
+        b = (b ?? "").Trim();
+        if (a.Length == 0 && b.Length == 0) { return 0; }
+        if (a.Length == 0) { return -1; }
+        if (b.Length == 0) { return 1; }
+
+        var (epochA, upstreamA, revisionA) = Split(a);
+        var (epochB, upstreamB, revisionB) = Split(b);
+
+        var cmp = epochA.CompareTo(epochB);
+        if (cmp != 0) { return cmp; }
+
+        cmp = VerRevCmp(upstreamA, upstreamB);
+        if (cmp != 0) { return cmp; }
+
+        return VerRevCmp(revisionA, revisionB);
+    }
+
+    // Splits "[epoch:]upstream[-revision]" into its three parts. Missing epoch → 0, missing revision → "".
+    private static (int Epoch, string Upstream, string Revision) Split(string v)
+    {
+        var epoch = 0;
+        var colon = v.IndexOf(':');
+        if (colon > 0 && int.TryParse(v.AsSpan(0, colon), out var e))
+        {
+            epoch = e;
+            v = v[(colon + 1)..];
+        }
+
+        // The Debian revision is everything after the LAST '-'.
+        // If there is no '-', the whole thing is upstream and the revision is empty.
+        var dash = v.LastIndexOf('-');
+        return dash >= 0
+            ? (epoch, v[..dash], v[(dash + 1)..])
+            : (epoch, v, "");
+    }
+
+    // The core dpkg comparison: alternate non-digit and digit segments.
+    private static int VerRevCmp(string a, string b)
+    {
+        var i = 0;
+        var j = 0;
+        while (i < a.Length || j < b.Length)
+        {
+            // 1) Non-digit run, with the Debian character ordering.
+            var diff = 0;
+            while ((i < a.Length && !char.IsDigit(a[i])) || (j < b.Length && !char.IsDigit(b[j])))
+            {
+                var ac = i < a.Length ? Order(a[i]) : 0;
+                var bc = j < b.Length ? Order(b[j]) : 0;
+                if (ac != bc) { return ac - bc; }
+                i++;
+                j++;
+            }
+
+            // 2) Skip leading zeros so the longer "number" wins only by value.
+            while (i < a.Length && a[i] == '0') { i++; }
+            while (j < b.Length && b[j] == '0') { j++; }
+
+            // 3) Digit run: the longer digit run wins; if same length, compare digit by digit.
+            while (i < a.Length && j < b.Length && char.IsDigit(a[i]) && char.IsDigit(b[j]))
+            {
+                if (diff == 0) { diff = a[i] - b[j]; }
+                i++;
+                j++;
+            }
+            if (i < a.Length && char.IsDigit(a[i])) { return 1; }
+            if (j < b.Length && char.IsDigit(b[j])) { return -1; }
+            if (diff != 0) { return diff; }
+        }
+        return 0;
+    }
+
+    // Debian sorting order for non-digit characters inside a version segment.
+    //   '~' sorts before everything, including the empty string (we return a NEGATIVE value).
+    //   Letters sort according to their code point.
+    //   Other characters (punctuation: +, -, .) sort AFTER letters: we offset by 256.
+    private static int Order(char c)
+    {
+        if (c == '~') { return -1; }
+        if (char.IsLetter(c)) { return c; }
+        return c + 256;
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests.csproj
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Corsinvest.ProxmoxVE.Diagnostic.Api\Corsinvest.ProxmoxVE.Diagnostic.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticEngineSafeTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticEngineSafeTests.cs
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using System.Dynamic;
+using System.Net;
+using Corsinvest.ProxmoxVE.Api;
+using Xunit;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api.Tests;
+
+/// <summary>
+/// The format of <see cref="DiagnosticSafeExtensions.BuildApiErrorMessage"/> is what users see
+/// in WG0042 findings. These tests pin the format so it does not regress silently.
+/// </summary>
+public class DiagnosticEngineSafeTests
+{
+    [Fact]
+    public void BuildApiErrorMessage_status_reason_and_path()
+    {
+        var r = MakeResult(HttpStatusCode.Forbidden, "Forbidden", "/cluster/firewall/options", responseError: null);
+        var msg = DiagnosticSafeExtensions.BuildApiErrorMessage(r);
+        Assert.Equal("403 Forbidden — Get /cluster/firewall/options", msg);
+    }
+
+    [Fact]
+    public void BuildApiErrorMessage_includes_api_error_body_when_present()
+    {
+        var r = MakeResult(HttpStatusCode.Forbidden, "Forbidden", "/cluster/firewall/options",
+                           responseError: "Permission check failed (/cluster, Sys.Audit)");
+        var msg = DiagnosticSafeExtensions.BuildApiErrorMessage(r);
+        // Result.GetError() prefixes each error entry with its key ("root : ...") — the
+        // formatter just embeds it verbatim, so the assertion mirrors the real PVE output shape.
+        Assert.Contains("403 Forbidden", msg);
+        Assert.Contains("Permission check failed (/cluster, Sys.Audit)", msg);
+        Assert.Contains("Get /cluster/firewall/options", msg);
+    }
+
+    [Fact]
+    public void BuildApiErrorMessage_omits_path_when_empty()
+    {
+        var r = MakeResult(HttpStatusCode.InternalServerError, "Internal Server Error", requestResource: "", responseError: null);
+        var msg = DiagnosticSafeExtensions.BuildApiErrorMessage(r);
+        Assert.Equal("500 Internal Server Error", msg);
+    }
+
+    [Fact]
+    public void BuildApiErrorMessage_handles_501_status()
+    {
+        // 501 is silenced upstream by the catch filter, but the formatter must still produce
+        // a sensible string in case any code path calls it for a 501.
+        var r = MakeResult(HttpStatusCode.NotImplemented, "Not Implemented", "/cluster/ha/groups", responseError: null);
+        var msg = DiagnosticSafeExtensions.BuildApiErrorMessage(r);
+        Assert.Equal("501 Not Implemented — Get /cluster/ha/groups", msg);
+    }
+
+    [Fact]
+    public void ApiErrorCode_is_stable()
+    {
+        // The WG0042 code is published in the README check table; flag accidental renames.
+        Assert.Equal("WG0042", DiagnosticSafeExtensions.ApiErrorCode);
+    }
+
+    // -------- helper --------
+
+    private static Result MakeResult(HttpStatusCode status, string reason, string requestResource, string? responseError)
+    {
+        dynamic response = new ExpandoObject();
+        if (responseError != null)
+        {
+            dynamic errors = new ExpandoObject();
+            ((IDictionary<string, object>)errors)["root"] = responseError;
+            ((IDictionary<string, object>)response)["errors"] = errors;
+        }
+
+        return new Result(response: response,
+                          statusCode: status,
+                          reasonPhrase: reason,
+                          isSuccessStatusCode: (int)status >= 200 && (int)status < 300,
+                          requestResource: requestResource,
+                          requestParameters: new Dictionary<string, object>(),
+                          methodType: MethodType.Get,
+                          responseType: ResponseType.Json,
+                          duration: TimeSpan.Zero);
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticResultTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticResultTests.cs
@@ -1,0 +1,199 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Xunit;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api.Tests;
+
+public class DiagnosticResultTests
+{
+    // -------- DecodeContext --------
+
+    [Theory]
+    [InlineData("node", DiagnosticResultContext.Node)]
+    [InlineData("Node", DiagnosticResultContext.Node)]
+    [InlineData("NODE", DiagnosticResultContext.Node)]
+    [InlineData("storage", DiagnosticResultContext.Storage)]
+    [InlineData("qemu", DiagnosticResultContext.Qemu)]
+    [InlineData("lxc", DiagnosticResultContext.Lxc)]
+    [InlineData("cluster", DiagnosticResultContext.Cluster)]
+    public void DecodeContext_recognises_known_values_case_insensitive(string text, DiagnosticResultContext expected)
+        => Assert.Equal(expected, DiagnosticResult.DecodeContext(text));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("unknown")]
+    [InlineData("vm")]              // PVE sometimes uses "vm" not "qemu" — falls through
+    public void DecodeContext_unknown_falls_back_to_Cluster(string text)
+        => Assert.Equal(DiagnosticResultContext.Cluster, DiagnosticResult.DecodeContext(text));
+
+    // -------- CheckIgnoreIssue: positive matches --------
+
+    [Fact]
+    public void CheckIgnoreIssue_exact_match_on_all_fields_returns_true()
+    {
+        var rule = new DiagnosticResult
+        {
+            Id = "nodes/pve01/qemu/100",
+            ErrorCode = "WG0017",
+            SubContext = "Backup",
+            Description = "vzdump backup not configured",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        var finding = new DiagnosticResult
+        {
+            Id = "nodes/pve01/qemu/100",
+            ErrorCode = "WG0017",
+            SubContext = "Backup",
+            Description = "vzdump backup not configured",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        Assert.True(rule.CheckIgnoreIssue(finding));
+    }
+
+    [Fact]
+    public void CheckIgnoreIssue_regex_pattern_matches_id_substring()
+    {
+        var rule = new DiagnosticResult
+        {
+            Id = @"nodes/pve01/qemu/\d+",       // regex matches any vmid on pve01
+            ErrorCode = "WG0017",
+            SubContext = "Backup",
+            Description = ".*",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        var finding = new DiagnosticResult
+        {
+            Id = "nodes/pve01/qemu/100",
+            ErrorCode = "WG0017",
+            SubContext = "Backup",
+            Description = "vzdump backup not configured",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        Assert.True(rule.CheckIgnoreIssue(finding));
+    }
+
+    [Fact]
+    public void CheckIgnoreIssue_pattern_on_description_matches_substring()
+    {
+        var rule = new DiagnosticResult
+        {
+            Id = ".*",
+            ErrorCode = "WG0019",
+            SubContext = "Backup",
+            Description = "older than 60 days",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        var finding = new DiagnosticResult
+        {
+            Id = "nodes/pve01/qemu/100",
+            ErrorCode = "WG0019",
+            SubContext = "Backup",
+            Description = "1 backup older than 60 days (88.05 GB)",
+            Context = DiagnosticResultContext.Qemu,
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        Assert.True(rule.CheckIgnoreIssue(finding));
+    }
+
+    // -------- CheckIgnoreIssue: negative matches --------
+
+    [Fact]
+    public void CheckIgnoreIssue_different_ErrorCode_returns_false()
+    {
+        var rule = MakeRule(errorCode: "WG0017");
+        var finding = MakeFinding(errorCode: "WG0019");
+        Assert.False(rule.CheckIgnoreIssue(finding));
+    }
+
+    [Fact]
+    public void CheckIgnoreIssue_different_Id_returns_false()
+    {
+        var rule = MakeRule(id: "nodes/pve01/qemu/100");
+        var finding = MakeFinding(id: "nodes/pve02/qemu/200");
+        Assert.False(rule.CheckIgnoreIssue(finding));
+    }
+
+    [Fact]
+    public void CheckIgnoreIssue_different_Context_returns_false()
+    {
+        var rule = MakeRule(context: DiagnosticResultContext.Qemu);
+        var finding = MakeFinding(context: DiagnosticResultContext.Lxc);
+        Assert.False(rule.CheckIgnoreIssue(finding));
+    }
+
+    // -------- CheckIgnoreIssue: documented quirks --------
+    // Context/Gravity defaults are treated as "any" so a rule can ignore across all contexts/gravities.
+
+    [Fact]
+    public void CheckIgnoreIssue_default_Context_matches_any()
+    {
+        var rule = new DiagnosticResult
+        {
+            Id = ".*", ErrorCode = ".*", SubContext = ".*", Description = ".*",
+            // Context left at default → should match any finding context
+            Gravity = DiagnosticResultGravity.Warning,
+        };
+        Assert.True(rule.CheckIgnoreIssue(MakeFinding(context: DiagnosticResultContext.Lxc)));
+        Assert.True(rule.CheckIgnoreIssue(MakeFinding(context: DiagnosticResultContext.Storage)));
+    }
+
+    // Gravity.Info == default(0), so an Info rule matches findings of any gravity by design.
+    // Documented here so a future change of enum order doesn't silently break ignore rules.
+    [Fact]
+    public void CheckIgnoreIssue_default_Gravity_Info_matches_any_gravity()
+    {
+        var rule = new DiagnosticResult
+        {
+            Id = ".*", ErrorCode = ".*", SubContext = ".*", Description = ".*",
+            Context = DiagnosticResultContext.Qemu,
+            // Gravity left at default (Info=0) → matches any
+        };
+        Assert.True(rule.CheckIgnoreIssue(MakeFinding(gravity: DiagnosticResultGravity.Critical)));
+        Assert.True(rule.CheckIgnoreIssue(MakeFinding(gravity: DiagnosticResultGravity.Warning)));
+    }
+
+    [Fact]
+    public void CheckIgnoreIssue_non_default_Gravity_must_match_exactly()
+    {
+        var rule = MakeRule(gravity: DiagnosticResultGravity.Warning);
+        Assert.False(rule.CheckIgnoreIssue(MakeFinding(gravity: DiagnosticResultGravity.Critical)));
+        Assert.True(rule.CheckIgnoreIssue(MakeFinding(gravity: DiagnosticResultGravity.Warning)));
+    }
+
+    // -------- helpers --------
+
+    private static DiagnosticResult MakeRule(
+        string id = ".*",
+        string errorCode = ".*",
+        string subContext = ".*",
+        string description = ".*",
+        DiagnosticResultContext context = DiagnosticResultContext.Qemu,
+        DiagnosticResultGravity gravity = DiagnosticResultGravity.Warning)
+        => new()
+        {
+            Id = id, ErrorCode = errorCode, SubContext = subContext, Description = description,
+            Context = context, Gravity = gravity,
+        };
+
+    private static DiagnosticResult MakeFinding(
+        string id = "nodes/pve01/qemu/100",
+        string errorCode = "WG0017",
+        string subContext = "Backup",
+        string description = "vzdump backup not configured",
+        DiagnosticResultContext context = DiagnosticResultContext.Qemu,
+        DiagnosticResultGravity gravity = DiagnosticResultGravity.Warning)
+        => new()
+        {
+            Id = id, ErrorCode = errorCode, SubContext = subContext, Description = description,
+            Context = context, Gravity = gravity,
+        };
+}

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticResultTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/DiagnosticResultTests.cs
@@ -138,7 +138,10 @@ public class DiagnosticResultTests
     {
         var rule = new DiagnosticResult
         {
-            Id = ".*", ErrorCode = ".*", SubContext = ".*", Description = ".*",
+            Id = ".*",
+            ErrorCode = ".*",
+            SubContext = ".*",
+            Description = ".*",
             // Context left at default → should match any finding context
             Gravity = DiagnosticResultGravity.Warning,
         };
@@ -153,7 +156,10 @@ public class DiagnosticResultTests
     {
         var rule = new DiagnosticResult
         {
-            Id = ".*", ErrorCode = ".*", SubContext = ".*", Description = ".*",
+            Id = ".*",
+            ErrorCode = ".*",
+            SubContext = ".*",
+            Description = ".*",
             Context = DiagnosticResultContext.Qemu,
             // Gravity left at default (Info=0) → matches any
         };
@@ -180,8 +186,12 @@ public class DiagnosticResultTests
         DiagnosticResultGravity gravity = DiagnosticResultGravity.Warning)
         => new()
         {
-            Id = id, ErrorCode = errorCode, SubContext = subContext, Description = description,
-            Context = context, Gravity = gravity,
+            Id = id,
+            ErrorCode = errorCode,
+            SubContext = subContext,
+            Description = description,
+            Context = context,
+            Gravity = gravity,
         };
 
     private static DiagnosticResult MakeFinding(
@@ -193,7 +203,11 @@ public class DiagnosticResultTests
         DiagnosticResultGravity gravity = DiagnosticResultGravity.Warning)
         => new()
         {
-            Id = id, ErrorCode = errorCode, SubContext = subContext, Description = description,
-            Context = context, Gravity = gravity,
+            Id = id,
+            ErrorCode = errorCode,
+            SubContext = subContext,
+            Description = description,
+            Context = context,
+            Gravity = gravity,
         };
 }

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/EnumerableExtensionsTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Xunit;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api.Tests;
+
+public class EnumerableExtensionsTests
+{
+    // -------- Sum --------
+
+    [Fact]
+    public void Sum_empty_returns_zero()
+        => Assert.Equal(0UL, Array.Empty<int>().Sum(_ => 0UL));
+
+    [Fact]
+    public void Sum_adds_selected_values()
+    {
+        var data = new[] { 1, 2, 3, 4 };
+        Assert.Equal(10UL, data.Sum(x => (ulong)x));
+    }
+
+    [Fact]
+    public void Sum_supports_large_totals_within_ulong_range()
+    {
+        // Realistic cluster scenario: summing per-node memory in bytes.
+        // 8 nodes × 1 TiB ≈ 8 * 2^40 = 8.8 * 10^12, well below ulong.MaxValue (1.8 * 10^19).
+        var data = Enumerable.Repeat(1UL << 40, 8);
+        Assert.Equal(8UL << 40, data.Sum(x => x));
+    }
+
+    // Documents the current behaviour: Sum does not protect against ulong overflow.
+    // It wraps around silently. The whole helper is internal and we control all callers,
+    // so the policy is "callers must ensure the running total fits"; this test pins the
+    // contract so a future change to a checked() arithmetic is a deliberate, visible decision.
+    [Fact]
+    public void Sum_wraps_silently_on_overflow()
+    {
+        var data = new[] { ulong.MaxValue, 1UL };
+        Assert.Equal(0UL, data.Sum(x => x));
+    }
+
+    // -------- Average --------
+
+    [Fact]
+    public void Average_computes_integer_mean()
+    {
+        var data = new[] { 10, 20, 30 };
+        Assert.Equal(20UL, data.Average(x => (ulong)x));
+    }
+
+    [Fact]
+    public void Average_truncates_toward_zero()
+    {
+        // Integer division: (1+2+2) / 3 = 5/3 = 1, not 1.67.
+        var data = new[] { 1, 2, 2 };
+        Assert.Equal(1UL, data.Average(x => (ulong)x));
+    }
+
+    // Documents the current behaviour: Average over an empty source throws DivideByZeroException.
+    // No caller in the engine passes an empty source today; if that ever changes, the caller
+    // must guard. This test pins the contract.
+    [Fact]
+    public void Average_empty_source_throws()
+        => Assert.Throws<DivideByZeroException>(() => Array.Empty<int>().Average(_ => 0UL));
+
+    // Average enumerates the source twice (once via Sum, once via Count). Pinning this so a
+    // future refactor to single-pass doesn't break callers that rely on stable two-pass behaviour
+    // (none today, but worth flagging if it changes).
+    [Fact]
+    public void Average_enumerates_source_twice()
+    {
+        var enumerated = 0;
+        IEnumerable<int> Source()
+        {
+            foreach (var i in new[] { 1, 2, 3 })
+            {
+                enumerated++;
+                yield return i;
+            }
+        }
+
+        Source().Average(x => (ulong)x);
+        Assert.Equal(6, enumerated);   // 3 items × 2 passes
+    }
+}

--- a/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/Helpers/DebianVersionTests.cs
+++ b/tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests/Helpers/DebianVersionTests.cs
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Corsinvest Srl
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+using Corsinvest.ProxmoxVE.Diagnostic.Api.Helpers;
+using Xunit;
+
+namespace Corsinvest.ProxmoxVE.Diagnostic.Api.Tests.Helpers;
+
+public class DebianVersionTests
+{
+    // ----- equality -----
+    [Theory]
+    [InlineData("1.0", "1.0")]
+    [InlineData("1.0-1", "1.0-1")]
+    [InlineData("0:1.0", "1.0")]               // explicit zero epoch == implicit
+    [InlineData("1.0-0", "1.0-0")]
+    [InlineData("8.2.4", "8.2.4")]
+    public void Compare_equal_versions_returns_zero(string a, string b)
+        => Assert.Equal(0, DebianVersion.Compare(a, b));
+
+    // ----- ordering: a < b -----
+    [Theory]
+    [InlineData("1.0", "1.1")]
+    [InlineData("1.0", "2.0")]
+    [InlineData("1.9", "1.10")]                // numeric, not lexical
+    [InlineData("8.2.4~rc1", "8.2.4")]         // ~ precedes everything, even nothing
+    [InlineData("8.2.4~rc1", "8.2.4~rc2")]
+    [InlineData("8.2.4", "8.2.4-1")]           // missing revision sorts before any revision
+    [InlineData("3.0.11-1~deb12u2", "3.0.11-1~deb12u3")]   // the real-world canary
+    [InlineData("1:9.9", "2:1.0")]             // epoch dominates
+    [InlineData("", "1.0")]                     // empty < any non-empty
+    public void Compare_less_than(string a, string b)
+        => Assert.True(DebianVersion.Compare(a, b) < 0,
+                       $"expected '{a}' < '{b}', got {DebianVersion.Compare(a, b)}");
+
+    // ----- ordering: a > b (mirror of above) -----
+    [Theory]
+    [InlineData("1.1", "1.0")]
+    [InlineData("8.2.4", "8.2.4~rc1")]
+    [InlineData("8.2.4-1", "8.2.4")]
+    [InlineData("3.0.11-1~deb12u3", "3.0.11-1~deb12u2")]
+    [InlineData("2:1.0", "1:9.9")]
+    [InlineData("1.0", "")]
+    public void Compare_greater_than(string a, string b)
+        => Assert.True(DebianVersion.Compare(a, b) > 0,
+                       $"expected '{a}' > '{b}', got {DebianVersion.Compare(a, b)}");
+
+    // ----- null / whitespace handling -----
+    [Fact]
+    public void Compare_both_null_returns_zero()
+        => Assert.Equal(0, DebianVersion.Compare(null, null));
+
+    [Fact]
+    public void Compare_null_lhs_returns_negative()
+        => Assert.True(DebianVersion.Compare(null, "1.0") < 0);
+
+    [Fact]
+    public void Compare_null_rhs_returns_positive()
+        => Assert.True(DebianVersion.Compare("1.0", null) > 0);
+
+    [Theory]
+    [InlineData("  1.0  ", "1.0")]
+    [InlineData("\t1.0\n", "1.0")]
+    public void Compare_trims_whitespace(string a, string b)
+        => Assert.Equal(0, DebianVersion.Compare(a, b));
+
+    // ----- tilde precedes everything (the tricky rule) -----
+    // ~ sorts BEFORE end-of-string, but a letter sorts AFTER end-of-string,
+    // so "1~~a" > "1~~" (same prefix, then 'a' vs nothing → 'a' wins).
+    [Theory]
+    [InlineData("1~", "1")]                    // ~ alone < nothing
+    [InlineData("1~~", "1~")]                  // earlier in the ~ chain
+    [InlineData("1~a", "1")]                   // ~a < nothing because the ~ at position 1 wins
+    public void Compare_tilde_sorts_before(string a, string b)
+        => Assert.True(DebianVersion.Compare(a, b) < 0,
+                       $"expected '{a}' < '{b}' (tilde rule)");
+
+    // ----- letters before non-letter symbols within a non-digit run -----
+    // Per Debian: in a non-digit run, letters sort before non-letter non-tilde chars.
+    // Note: '-' splits upstream/revision so it can't be tested directly inside upstream.
+    [Theory]
+    [InlineData("1.0a", "1.0+")]               // 'a' (letter) < '+' (symbol)
+    public void Compare_letters_before_symbols(string a, string b)
+        => Assert.True(DebianVersion.Compare(a, b) < 0,
+                       $"expected '{a}' < '{b}' (letter-before-symbol rule)");
+
+    // ----- subtle ~ + letter interactions (regression guard) -----
+    // After equal prefix "1~~", left has "a" and right has end-of-string.
+    // Letters sort AFTER end-of-string, so "1~~a" > "1~~".
+    [Fact]
+    public void Compare_letter_after_tilde_chain_is_greater_than_chain_alone()
+        => Assert.True(DebianVersion.Compare("1~~a", "1~~") > 0);
+
+    // ----- the CVE use case: skip when installed >= fixed -----
+    [Theory]
+    [InlineData("3.0.11-1~deb12u3", "3.0.11-1~deb12u2", true)]   // installed newer → patched
+    [InlineData("3.0.11-1~deb12u2", "3.0.11-1~deb12u2", true)]   // installed equal → patched
+    [InlineData("3.0.11-1~deb12u1", "3.0.11-1~deb12u2", false)]  // installed older → still vulnerable
+    public void Compare_models_the_fixed_version_check(string installed, string fixedInRelease, bool patched)
+    {
+        var cmp = DebianVersion.Compare(installed, fixedInRelease);
+        Assert.Equal(patched, cmp >= 0);
+    }
+}


### PR DESCRIPTION
## Summary

### CVE accuracy
- **`fixed_version` honored on Debian Security Tracker** — when the installed package is already at or beyond the published fix, the CVE is skipped. Removes the main source of false-positive CVE findings for already-patched packages.
- **NVD queried by CPE** — `cpeName=cpe:2.3:a:proxmox:virtual_environment:*` with `resultsPerPage=2000` (NVD max). The server returns only Proxmox VE entries (no Salt/Jenkins/Foreman/Terraform to filter client-side) and no historical CVE is truncated by paging.
- **Failures surfaced as findings** — a CVE fetch that fails now emits a `WG0042` Warning instead of silently leaving the result empty (which was being read as "no vulnerabilities").
- **Skip low-quality NVD entries** — CVE with no CVSS score or no English description are dropped (would have produced findings with nothing actionable).
- **Per-task timeout** — Debian and NVD no longer share the same 120 s `CancellationTokenSource`.

### Version comparison
- New `Helpers/DebianVersion` implementing the `dpkg --compare-versions` (`verrevcmp`) algorithm: epoch, upstream/revision split, the `~`-sorts-before-everything rule, letters-before-symbols inside non-digit runs.
- Replaces the ad-hoc `CompareVersions` used in both the Debian check (vs `fixed_version`) and the NVD check (vs `versionEnd`).

### Refactor
- `FetchDebianCveAsync` / `FetchNvdCveAsync` extracted from one long `Task.Run` block.
- Per-CVE parsing split into `ExtractEnglishDescription`, `ExtractCvss`, `ExtractProxmoxVersionRange` to flatten the previously 3-level nested loops.

### Tests
- New `tests/Corsinvest.ProxmoxVE.Diagnostic.Api.Tests` (xUnit, `net10.0`), wired into the solution under a `/tests/` folder.
- **66 unit tests** covering:
  - `DebianVersion` (33) — equality, ordering, `~` rule, epoch, revision, null
  - `DiagnosticResult` (18) — `DecodeContext`, `CheckIgnoreIssue` (regex match, mismatch, documented default-value quirks)
  - `DiagnosticEngine.Safe` (5) — `BuildApiErrorMessage` format pinned + `ApiErrorCode` stability
  - `EnumerableExtensions` (10) — `Sum` (incl. overflow), `Average` (incl. divide-by-zero and double-enumeration)
- `InternalsVisibleTo` added to the Api project so tests can reach internal helpers.

## Test plan
- [ ] `dotnet test` — all 66 tests green.
- [ ] Run `cv4pve-diag execute` with `Cve.DebianTrackerEnabled = true` against a node where a CVE has a known `fixed_version` you are above: no finding.
- [ ] Same against a node still at a vulnerable version: finding emitted.
- [ ] Disable internet / block the tracker URL: `WG0042` finding appears, analysis still completes.
- [ ] `Cve.NvdEnabled = true` with a vulnerable `pve-manager`: relevant NVD CVE reported; with a current `pve-manager`: skipped.