### PR TITLE
feat: 16 new diagnostic checks derived from cv4pve-report compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@
 
 ## [Unreleased]
 
+### New checks
+
+**Access:**
+- `WC0013` — User holds Administrator role transitively via a group but has no TFA.
+- `WC0014` — Disabled user still has Administrator role on `/`.
+- `WC0015` — `root@pam` has API tokens with no privilege separation (token holds full root rights).
+- `WC0016` — User is still enabled past its expiration date.
+- `IC0010` — Administrator ACL on `/` with Propagate disabled — children resources do not inherit.
+- `IC0011` — External realm (LDAP / AD / OpenID) does not enforce TFA at realm level.
+
+**Backup:**
+- `WC0017` — Enabled backup job has no schedule — it will never run automatically.
+- `WC0018` — Recent backup task ended with a non-OK status.
+- `IC0012` — Backup job is currently disabled.
+
+**Firewall:**
+- `IC0013` — Cluster firewall has enabled rules but none configure logging — no audit trail.
+- `IC0014` — Cluster firewall has 10+ disabled rules — stale configuration.
+
+**Cluster:**
+- `IC0015` — 10+ error-level entries in the recent cluster journal.
+- `IC0016` — 10%+ of recent cluster tasks failed — investigate recurring errors.
+- `IC0017` — Cluster has a single node — HA, quorum and replication provide no real protection.
+
+**Per guest:**
+- `IG0015` — Running guest is not covered by any HA resource.
+- `WG0025` — HA guest has no enabled replication job — on non-shared storage the failover target will have no recent data.
+
 ### CVE checks
 
 - `CN0014` / `WN0041` (Debian Security Tracker) — a CVE is no longer reported for a package that is already at or beyond the released fix. Removes most false positives on patched systems.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,20 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | User without email                  | IC0007 | Access      | Info     | Enabled user has no email — will not receive notifications               |
 | Empty group                         | IC0008 | Access      | Info     | Group has no members                                                     |
 | Unused custom role                  | IC0009 | Access      | Info     | Custom role is not assigned in any ACL                                   |
+| Admin via group without TFA         | WC0013 | Access      | Warning  | User has Administrator role via a group but no TFA configured            |
+| Disabled user still admin           | WC0014 | Access      | Warning  | Disabled user still has Administrator role on `/`                        |
+| Admin ACL not propagated            | IC0010 | Access      | Info     | Administrator role on `/` with Propagate disabled                        |
+| External realm without TFA          | IC0011 | Access      | Info     | LDAP/AD/OpenID realm does not enforce TFA at realm level                 |
+| root@pam token without privsep      | WC0015 | Access      | Warning  | root@pam API token has no privilege separation                           |
+| User expired but still enabled      | WC0016 | Access      | Warning  | User has expiration date in the past but is still enabled                |
+| Backup job without schedule         | WC0017 | Backup      | Warning  | Enabled backup job has no schedule — will never run                      |
+| Disabled backup job                 | IC0012 | Backup      | Info     | Backup job is disabled                                                   |
+| Backup task failed                  | WC0018 | Backup      | Warning  | Recent vzdump task ended with non-OK status                              |
+| Firewall without logging            | IC0013 | Firewall    | Info     | Cluster firewall has enabled rules but none configure logging            |
+| Many disabled firewall rules        | IC0014 | Firewall    | Info     | Cluster firewall has 10+ disabled rules — stale configuration            |
+| Cluster log has errors              | IC0015 | Log         | Info     | 10+ error-level entries in the cluster journal                           |
+| High task failure rate              | IC0016 | Tasks       | Info     | 10%+ of recent cluster tasks failed                                      |
+| Single-node "cluster"               | IC0017 | Topology    | Info     | Cluster has a single node — HA / quorum / replication ineffective       |
 | Nodes PVE version mismatch          | WC0011 | Version     | Warning  | Online nodes run different Proxmox VE versions                           |
 | Nodes kernel mismatch               | WC0012 | Version     | Warning  | Online nodes run different kernel versions                               |
 

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
@@ -19,7 +19,7 @@ public partial class DiagnosticEngine
         var hasCluster = clusterConfigNodes.Any();
         _clusterBackups = clusterBackupTask.Result;
 
-        CheckClusterBackupCompression();
+        await CheckClusterBackupAsync();
 
         if (hasCluster)
         {
@@ -31,11 +31,50 @@ public partial class DiagnosticEngine
         await CheckClusterPoolsAsync();
         await CheckClusterFirewallAsync();
         await CheckClusterAccessAsync();
+        await CheckClusterLogAsync();
+
+        // Single-node "cluster": HA, quorum and replication are not effective.
+        // Counted independently of hasCluster so even a non-clustered single host gets the hint.
+        var nodeCount = _resources.Count(a => a.ResourceType == ClusterResourceType.Node);
+        if (nodeCount == 1)
+        {
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster",
+                ErrorCode = "IC0017",
+                Description = "Cluster has a single node — HA, quorum and replication provide no real protection",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "Topology",
+                Gravity = DiagnosticResultGravity.Info,
+            });
+        }
 
         return hasCluster;
     }
 
-    private void CheckClusterBackupCompression()
+    private async Task CheckClusterLogAsync()
+    {
+        // 200 recent entries — enough to catch a burst of errors without dragging the whole journal.
+        var entries = await client.Cluster.Log.GetAsync(max: 200)
+                            .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "cluster log");
+
+        // syslog priorities 0..3 are emerg/alert/crit/err — anything above is warning/info/debug.
+        var errors = entries.Count(e => e.Severity >= 0 && e.Severity <= 3);
+        if (errors >= 10)
+        {
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster",
+                ErrorCode = "IC0015",
+                Description = $"Cluster log has {errors} error-level entries in the last 200 — review the journal",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "Log",
+                Gravity = DiagnosticResultGravity.Info,
+            });
+        }
+    }
+
+    private async Task CheckClusterBackupAsync()
     {
         var backupList = _clusterBackups.ToList();
 
@@ -83,6 +122,69 @@ public partial class DiagnosticEngine
                                        SubContext = "Backup",
                                        Gravity = DiagnosticResultGravity.Warning,
                                    }));
+
+        // Enabled backup job with no schedule: it will never run automatically.
+        _result.AddRange(backupList.Where(a => a.Enabled && string.IsNullOrWhiteSpace(a.Schedule))
+                                   .Select(a => new DiagnosticResult
+                                   {
+                                       Id = $"cluster/backup/{a.Id}",
+                                       ErrorCode = "WC0017",
+                                       Description = $"Backup job '{a.Id}' is enabled but has no schedule — it will never run automatically",
+                                       Context = DiagnosticResultContext.Cluster,
+                                       SubContext = "Backup",
+                                       Gravity = DiagnosticResultGravity.Warning,
+                                   }));
+
+        // Disabled backup jobs: informational, often leftover configuration worth reviewing.
+        _result.AddRange(backupList.Where(a => !a.Enabled)
+                                   .Select(a => new DiagnosticResult
+                                   {
+                                       Id = $"cluster/backup/{a.Id}",
+                                       ErrorCode = "IC0012",
+                                       Description = $"Backup job '{a.Id}' is currently disabled",
+                                       Context = DiagnosticResultContext.Cluster,
+                                       SubContext = "Backup",
+                                       Gravity = DiagnosticResultGravity.Info,
+                                   }));
+
+        // Cluster-wide task feed — used here for recent backup failures and below for task error rate.
+        var clusterTasks = (await client.Cluster.Tasks.GetAsync()
+                                  .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "cluster task feed"))
+                                  .ToList();
+
+        // Recent vzdump task that did not complete successfully — backup likely failed.
+        _result.AddRange(clusterTasks.Where(t => (t.Type?.StartsWith("vzdump", StringComparison.OrdinalIgnoreCase) ?? false)
+                                                 && t.EndTime > 0
+                                                 && !string.Equals(t.Status, "OK", StringComparison.OrdinalIgnoreCase))
+                                     .Select(t => new DiagnosticResult
+                                     {
+                                         Id = $"nodes/{t.Node}",
+                                         ErrorCode = "WC0018",
+                                         Description = $"Backup task on node '{t.Node}' by '{t.User}' ended with status '{t.Status}'",
+                                         Context = DiagnosticResultContext.Cluster,
+                                         SubContext = "Backup",
+                                         Gravity = DiagnosticResultGravity.Warning,
+                                     }));
+
+        // Overall task failure rate — sustained failures across the cluster usually indicate a systemic issue.
+        var finishedTasks = clusterTasks.Where(t => t.EndTime > 0).ToList();
+        if (finishedTasks.Count >= 10)
+        {
+            var failed = finishedTasks.Count(t => !string.Equals(t.Status, "OK", StringComparison.OrdinalIgnoreCase));
+            var ratio = (double)failed / finishedTasks.Count;
+            if (ratio >= 0.10)
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = "cluster",
+                    ErrorCode = "IC0016",
+                    Description = $"Cluster task failure rate is {ratio:P0} ({failed}/{finishedTasks.Count}) — investigate recurring errors",
+                    Context = DiagnosticResultContext.Cluster,
+                    SubContext = "Tasks",
+                    Gravity = DiagnosticResultGravity.Info,
+                });
+            }
+        }
     }
 
     private async Task CheckClusterHaAndReplicationAsync()
@@ -92,6 +194,18 @@ public partial class DiagnosticEngine
         var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync();
         var replJobsTask = client.Cluster.Replication.GetAsync();
         await Task.WhenAll(haResourcesTask, haStatusTask, replJobsTask);
+
+        // Cache the guest ids referenced by HA / enabled replication so per-guest checks don't re-walk them.
+        foreach (var h in haResourcesTask.Result)
+        {
+            // Sid format is "<type>:<vmid>" — e.g. "vm:100", "ct:200".
+            var parts = (h.Sid ?? "").Split(':');
+            if (parts.Length == 2 && long.TryParse(parts[1], out var vmid)) { _haVmIds.Add(vmid); }
+        }
+        foreach (var r in replJobsTask.Result.Where(r => !r.Disable && !string.IsNullOrWhiteSpace(r.Guest)))
+        {
+            if (long.TryParse(r.Guest, out var vmid)) { _replicatedVmIds.Add(vmid); }
+        }
 
         if (!haResourcesTask.Result.Any())
         {
@@ -300,7 +414,7 @@ public partial class DiagnosticEngine
         }
 
         // Cluster firewall rules with source or dest 0.0.0.0/0 — overly permissive
-        var clusterRules = await client.Cluster.Firewall.Rules.GetAsync();
+        var clusterRules = (await client.Cluster.Firewall.Rules.GetAsync()).ToList();
         _result.AddRange(clusterRules.Where(r => r.Enable
                                                  && (r.Source == "0.0.0.0/0" || r.Dest == "0.0.0.0/0"))
                                      .Select(r => new DiagnosticResult
@@ -312,6 +426,39 @@ public partial class DiagnosticEngine
                                          SubContext = "Firewall",
                                          Gravity = DiagnosticResultGravity.Warning,
                                      }));
+
+        // Cluster firewall is enabled but no enabled rule has logging configured — no audit trail.
+        // "nolog" or empty disables logging; anything else (warning, info, debug, …) is considered logging.
+        var enabledRules = clusterRules.Where(r => r.Enable).ToList();
+        if (enabledRules.Count > 0
+            && !enabledRules.Any(r => !string.IsNullOrWhiteSpace(r.Log)
+                                      && !string.Equals(r.Log, "nolog", StringComparison.OrdinalIgnoreCase)))
+        {
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster/firewall/rules",
+                ErrorCode = "IC0013",
+                Description = $"Cluster firewall has {enabledRules.Count} enabled rules but none have logging configured — no audit trail",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "Firewall",
+                Gravity = DiagnosticResultGravity.Info,
+            });
+        }
+
+        // Many disabled rules cluster-wide — stale configuration accumulating noise.
+        var disabledCount = clusterRules.Count(r => !r.Enable);
+        if (disabledCount >= 10)
+        {
+            _result.Add(new DiagnosticResult
+            {
+                Id = "cluster/firewall/rules",
+                ErrorCode = "IC0014",
+                Description = $"Cluster firewall has {disabledCount} disabled rules — consider cleaning up stale configuration",
+                Context = DiagnosticResultContext.Cluster,
+                SubContext = "Firewall",
+                Gravity = DiagnosticResultGravity.Info,
+            });
+        }
     }
 
     private async Task CheckClusterAccessAsync()
@@ -322,12 +469,14 @@ public partial class DiagnosticEngine
         var aclsTask = client.Access.Acl.GetAsync();
         var groupsTask = client.Access.Groups.GetAsync();
         var rolesTask = client.Access.Roles.GetAsync();
-        await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask, groupsTask, rolesTask);
+        var domainsTask = client.Access.Domains.GetAsync();
+        await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask, groupsTask, rolesTask, domainsTask);
         var accessUsers = accessUsersTask.Result;
         var tfaEntries = tfaEntriesTask.Result;
         var acls = aclsTask.Result;
         var groups = groupsTask.Result;
         var roles = rolesTask.Result;
+        var domains = domainsTask.Result;
 
         var usersWithTfa = tfaEntries.Where(t => t.Entries?.Any() is true)
                                      .Select(t => t.UserId)
@@ -459,5 +608,100 @@ public partial class DiagnosticEngine
                                   SubContext = "Access",
                                   Gravity = DiagnosticResultGravity.Info,
                               }));
+
+        // Groups holding Administrator role on '/': any enabled member without TFA is a security risk.
+        // WC0007 covers users with direct ACL; this covers users that get admin transitively via group.
+        var privilegedGroupIds = acls.Where(a => a.Path == "/" && a.Type == "group" && a.Roleid == "Administrator")
+                                     .Select(a => a.UsersGroupid)
+                                     .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var g in groups.Where(g => privilegedGroupIds.Contains(g.Id) && !string.IsNullOrWhiteSpace(g.Users)))
+        {
+            foreach (var member in g.Users.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (usersWithTfa.Contains(member)) { continue; }
+                var u = accessUsers.FirstOrDefault(x => string.Equals(x.Id, member, StringComparison.OrdinalIgnoreCase));
+                if (u != null && !u.Enable) { continue; }
+                _result.Add(new DiagnosticResult
+                {
+                    Id = $"access/users/{member}",
+                    ErrorCode = "WC0013",
+                    Description = $"User '{member}' has Administrator role via group '{g.Id}' but no TFA configured",
+                    Context = DiagnosticResultContext.Cluster,
+                    SubContext = "Access",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
+            }
+        }
+
+        // Disabled user that still has Administrator ACL on '/': leftover privilege from before deactivation.
+        var disabledUserIds = accessUsers.Where(u => !u.Enable)
+                                         .Select(u => u.Id)
+                                         .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        _result.AddRange(acls.Where(a => a.Path == "/" && a.Type == "user" && a.Roleid == "Administrator"
+                                         && disabledUserIds.Contains(a.UsersGroupid))
+                             .Select(a => new DiagnosticResult
+                             {
+                                 Id = $"access/users/{a.UsersGroupid}",
+                                 ErrorCode = "WC0014",
+                                 Description = $"Disabled user '{a.UsersGroupid}' still has Administrator role on '/' — revoke the ACL entry",
+                                 Context = DiagnosticResultContext.Cluster,
+                                 SubContext = "Access",
+                                 Gravity = DiagnosticResultGravity.Warning,
+                             }));
+
+        // Administrator ACL on '/' with Propagate disabled: unusual, often a misconfiguration.
+        _result.AddRange(acls.Where(a => a.Path == "/" && a.Roleid == "Administrator" && a.Propagate == 0)
+                             .Select(a => new DiagnosticResult
+                             {
+                                 Id = "access/acl",
+                                 ErrorCode = "IC0010",
+                                 Description = $"{a.Type} '{a.UsersGroupid}' has Administrator role on '/' but Propagate is disabled — children resources do not inherit it",
+                                 Context = DiagnosticResultContext.Cluster,
+                                 SubContext = "Access",
+                                 Gravity = DiagnosticResultGravity.Info,
+                             }));
+
+        // External realm (LDAP/AD/OpenID) without realm-level TFA: weaker baseline than pve/pam where per-user TFA can be enforced.
+        _result.AddRange(domains.Where(d => string.IsNullOrWhiteSpace(d.Tfa)
+                                            && (string.Equals(d.Type, "ldap", StringComparison.OrdinalIgnoreCase)
+                                                || string.Equals(d.Type, "ad", StringComparison.OrdinalIgnoreCase)
+                                                || string.Equals(d.Type, "openid", StringComparison.OrdinalIgnoreCase)))
+                                .Select(d => new DiagnosticResult
+                                {
+                                    Id = $"access/domains/{d.Realm}",
+                                    ErrorCode = "IC0011",
+                                    Description = $"External realm '{d.Realm}' ({d.Type}) does not enforce TFA at realm level",
+                                    Context = DiagnosticResultContext.Cluster,
+                                    SubContext = "Access",
+                                    Gravity = DiagnosticResultGravity.Info,
+                                }));
+
+        // root@pam API tokens without privilege separation inherit full root rights — they should always be priv-separated.
+        if (root != null)
+        {
+            _result.AddRange(root.Tokens.Where(t => t.Privsep == 0)
+                                        .Select(t => new DiagnosticResult
+                                        {
+                                            Id = $"access/users/root@pam",
+                                            ErrorCode = "WC0015",
+                                            Description = $"root@pam token '{t.Id}' has no privilege separation — it has full root rights",
+                                            Context = DiagnosticResultContext.Cluster,
+                                            SubContext = "Access",
+                                            Gravity = DiagnosticResultGravity.Warning,
+                                        }));
+        }
+
+        // Enabled user whose expiration has already passed: account should have been deactivated.
+        var nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        _result.AddRange(accessUsers.Where(u => u.Enable && u.Expire > 0 && u.Expire < nowUnix)
+                                    .Select(u => new DiagnosticResult
+                                    {
+                                        Id = $"access/users/{u.Id}",
+                                        ErrorCode = "WC0016",
+                                        Description = $"User '{u.Id}' is enabled but expired on {DateTimeOffset.FromUnixTimeSeconds(u.Expire):yyyy-MM-dd} — account should be deactivated",
+                                        Context = DiagnosticResultContext.Cluster,
+                                        SubContext = "Access",
+                                        Gravity = DiagnosticResultGravity.Warning,
+                                    }));
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
@@ -279,6 +279,41 @@ public partial class DiagnosticEngine
                         ? rrdList.Average(a => Convert.ToDouble(a.MemoryUsage) / Convert.ToDouble(a.MemorySize) * 100.0)
                         : 0.0;
         CheckHealthScore(_result, thresholdHost.HealthScore, context, id, (cpuPct * 0.5) + (ramPct * 0.5));
+
+        // HA / Replication coverage — only meaningful for running, non-template guests.
+        // IC0002 / IC0003 already cover the "no HA at all / no replication at all" cluster-wide cases;
+        // these two flag individual guests that are NOT covered when the cluster has HA/replication in use.
+        var resource = _resources.FirstOrDefault(r => r.VmId == vmId);
+        if (resource != null && !resource.IsTemplate && resource.IsRunning)
+        {
+            if (_haVmIds.Count > 0 && !_haVmIds.Contains(vmId))
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = id,
+                    ErrorCode = "IG0015",
+                    Description = "Guest is not managed by any HA resource — it will not be restarted automatically on node failure",
+                    Context = context,
+                    SubContext = "HA",
+                    Gravity = DiagnosticResultGravity.Info,
+                });
+            }
+
+            // If the guest is in HA on non-shared storage, replication is the only way the failover target
+            // has a recent copy. Flag HA guests with no enabled replication job.
+            if (_haVmIds.Contains(vmId) && !_replicatedVmIds.Contains(vmId))
+            {
+                _result.Add(new DiagnosticResult
+                {
+                    Id = id,
+                    ErrorCode = "WG0025",
+                    Description = "HA guest has no enabled replication job — on non-shared storage the failover target will have no recent data",
+                    Context = context,
+                    SubContext = "Replication",
+                    Gravity = DiagnosticResultGravity.Warning,
+                });
+            }
+        }
     }
 
     private static void CheckTaskHistory(List<DiagnosticResult> result,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
@@ -23,6 +23,12 @@ public partial class DiagnosticEngine(PveClient client, Settings settings, HttpC
     private Dictionary<long, VmConfig> _vmConfigs = [];
     private Dictionary<string, IEnumerable<NodeStorage>> _backupStoragesByNode = [];
 
+    // HA-resource ids (vmid) and guest-ids targeted by enabled replication jobs.
+    // Populated by CheckClusterHaAndReplicationAsync and consumed by per-guest checks
+    // (VmsWithoutHaResource, VmsWithoutReplication) — saves re-fetching for every guest.
+    private readonly HashSet<long> _haVmIds = [];
+    private readonly HashSet<long> _replicatedVmIds = [];
+
     // One entry per unique storage: shared storages appear once (deduped by name),
     // non-shared appear once per node. Used everywhere instead of filtering _resources.
     private List<ClusterResource> _storageResources = [];


### PR DESCRIPTION
## Summary
Brings into diag the compliance checks that lived only in cv4pve-report's `feat/compliance` branch. These are operational checks that belong here (diag is the checker, report is the reportistic).

Three new cluster-level API calls (`Access.Domains`, `Cluster.Tasks`, `Cluster.Log`) — fetched once and cached. HA-resource and replication ids are cached on the engine so the per-guest checks don't re-walk them for every VM/CT.

## New checks (16)

### Access
| Code | Check | Severity |
|---|---|---|
| `WC0013` | User holds Administrator via a group but no TFA | Warning |
| `WC0014` | Disabled user still has Administrator on `/` | Warning |
| `WC0015` | `root@pam` token without privilege separation | Warning |
| `WC0016` | User still enabled past expiration date | Warning |
| `IC0010` | Administrator ACL on `/` with Propagate disabled | Info |
| `IC0011` | External realm (LDAP/AD/OpenID) without realm-level TFA | Info |

### Backup
| Code | Check | Severity |
|---|---|---|
| `WC0017` | Enabled backup job has no schedule | Warning |
| `WC0018` | Recent vzdump task ended non-OK | Warning |
| `IC0012` | Backup job is disabled | Info |

### Firewall
| Code | Check | Severity |
|---|---|---|
| `IC0013` | Enabled rules but none configure logging | Info |
| `IC0014` | 10+ disabled rules cluster-wide | Info |

### Cluster
| Code | Check | Severity |
|---|---|---|
| `IC0015` | 10+ error-level entries in cluster journal | Info |
| `IC0016` | 10%+ recent cluster tasks failed | Info |
| `IC0017` | Single-node cluster (HA / quorum ineffective) | Info |

### Per guest
| Code | Check | Severity |
|---|---|---|
| `IG0015` | Running guest not covered by any HA resource | Info |
| `WG0025` | HA guest with no enabled replication job | Warning |

## Skipped
- **MetricServerNotConfigured / MetricServersAllDisabled** — the SDK exposes the metric-server endpoint only as a raw `Result` (no typed model). Adding a `ClusterMetricServer` model upstream first would keep diag's style consistent.

README and `CHANGELOG.md` `[Unreleased]` updated.

## Test plan
- [ ] `dotnet test` — all 66 existing tests green.
- [ ] Run against a cluster with: a group that grants Administrator to a TFA-less member → `WC0013`. A disabled user still in admin ACL → `WC0014`. Realm LDAP without TFA → `IC0011`. Backup job with empty schedule → `WC0017`. Single-node setup → `IC0017`. Running guest not in HA on an HA cluster → `IG0015`. HA guest with no replication → `WG0025`.
- [ ] Healthy cluster — none of the new checks fires.