### PR TITLE
feat(resilience): wrap remaining cluster fetches with ToSafe*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Resilience
+
+- All remaining cluster fetches are now resilient: a failing call (access, HA, replication, firewall options/rules, pools, status, log, tasks, RRD) no longer aborts the analysis. The affected check is skipped and a `WG0042` Warning is recorded, consistently with what was already in place for per-node and per-guest fetches.
+
 ### New checks
 
 **Access:**

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cluster.cs
@@ -12,8 +12,10 @@ public partial class DiagnosticEngine
 {
     private async Task<bool> CheckClusterAsync(int pveMajorVersion)
     {
-        var clusterConfigNodesTask = client.Cluster.Config.Nodes.GetAsync();
-        var clusterBackupTask = client.Cluster.Backup.GetAsync();
+        var clusterConfigNodesTask = client.Cluster.Config.Nodes.GetAsync()
+                                            .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "cluster config nodes");
+        var clusterBackupTask = client.Cluster.Backup.GetAsync()
+                                      .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "cluster backup jobs");
         await Task.WhenAll(clusterConfigNodesTask, clusterBackupTask);
         var clusterConfigNodes = clusterConfigNodesTask.Result;
         var hasCluster = clusterConfigNodes.Any();
@@ -23,7 +25,8 @@ public partial class DiagnosticEngine
 
         if (hasCluster)
         {
-            var clusterStatus = await client.Cluster.Status.GetAsync();
+            var clusterStatus = await client.Cluster.Status.GetAsync()
+                                      .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "cluster status");
             await CheckClusterQuorumAndHaAsync(clusterStatus, pveMajorVersion);
             await CheckClusterHaAndReplicationAsync();
         }
@@ -190,9 +193,12 @@ public partial class DiagnosticEngine
     private async Task CheckClusterHaAndReplicationAsync()
     {
         // Cluster without any HA resource configured — no automatic failover on node failure
-        var haResourcesTask = client.Cluster.Ha.Resources.GetAsync();
-        var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync();
-        var replJobsTask = client.Cluster.Replication.GetAsync();
+        var haResourcesTask = client.Cluster.Ha.Resources.GetAsync()
+                                    .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "HA resources");
+        var haStatusTask = client.Cluster.Ha.Status.Current.GetAsync()
+                                 .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "HA status");
+        var replJobsTask = client.Cluster.Replication.GetAsync()
+                                 .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "replication jobs");
         await Task.WhenAll(haResourcesTask, haStatusTask, replJobsTask);
 
         // Cache the guest ids referenced by HA / enabled replication so per-guest checks don't re-walk them.
@@ -320,7 +326,8 @@ public partial class DiagnosticEngine
                                             .Select(a => a.Node)
                                             .ToHashSet();
 
-            foreach (var haGroup in await client.Cluster.Ha.Groups.GetAsync())
+            foreach (var haGroup in await client.Cluster.Ha.Groups.GetAsync()
+                                          .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "HA groups"))
             {
                 if (string.IsNullOrWhiteSpace(haGroup.Nodes)) { continue; }
                 var groupNodes = haGroup.Nodes.Split(',').Select(n => n.Split(':')[0].Trim());
@@ -343,7 +350,8 @@ public partial class DiagnosticEngine
 
     // Pools with no VMs and no storage assigned serve no purpose
     private async Task CheckClusterPoolsAsync()
-    => _result.AddRange((await client.Pools.GetAsync())
+    => _result.AddRange((await client.Pools.GetAsync()
+                                .ToSafeEnum(_result, "cluster", DiagnosticResultContext.Cluster, "pools"))
                             .Where(a => !_resources.Any(r => r.Pool == a.Id))
                             .Select(a => new DiagnosticResult
                             {
@@ -357,7 +365,10 @@ public partial class DiagnosticEngine
 
     private async Task CheckClusterFirewallAsync()
     {
-        var clusterFwOptions = await client.Cluster.Firewall.Options.GetAsync();
+        var clusterFwOptions = await client.Cluster.Firewall.Options.GetAsync()
+                                     .ToSafeSingle(_result, "cluster", DiagnosticResultContext.Cluster, "cluster firewall options");
+        // If the fetch failed we already recorded a finding — nothing else this method can do.
+        if (clusterFwOptions == null) { return; }
 
         // Cluster firewall completely disabled — no traffic filtering at all
         if (!clusterFwOptions.Enable)
@@ -394,12 +405,16 @@ public partial class DiagnosticEngine
             }
         }
 
-        // Firewall enabled at cluster level but disabled on individual nodes — inconsistent protection
+        // Firewall enabled at cluster level but disabled on individual nodes — inconsistent protection.
+        // The per-node fetch is wrapped: a single faulty node degrades to null and is silently skipped
+        // (the failure was already recorded as a finding by ToSafeSingle).
         var onlineNodes = _resources.Where(a => a.ResourceType == ClusterResourceType.Node && a.IsOnline).ToList();
-        var nodeFwResults = await RunParallelAsync(onlineNodes, node => client.Nodes[node.Node].Firewall.Options.GetAsync());
+        var nodeFwResults = await RunParallelAsync(onlineNodes,
+            node => client.Nodes[node.Node].Firewall.Options.GetAsync()
+                          .ToSafeSingle(_result, node.GetWebUrl(), DiagnosticResultContext.Node, $"firewall options on node '{node.Node}'"));
         foreach (var (node, nodeFwOptions) in onlineNodes.Zip(nodeFwResults))
         {
-            if (!nodeFwOptions.Enable)
+            if (nodeFwOptions != null && !nodeFwOptions.Enable)
             {
                 _result.Add(new DiagnosticResult
                 {
@@ -414,7 +429,8 @@ public partial class DiagnosticEngine
         }
 
         // Cluster firewall rules with source or dest 0.0.0.0/0 — overly permissive
-        var clusterRules = (await client.Cluster.Firewall.Rules.GetAsync()).ToList();
+        var clusterRules = (await client.Cluster.Firewall.Rules.GetAsync()
+                                  .ToSafeEnum(_result, "cluster/firewall/rules", DiagnosticResultContext.Cluster, "cluster firewall rules")).ToList();
         _result.AddRange(clusterRules.Where(r => r.Enable
                                                  && (r.Source == "0.0.0.0/0" || r.Dest == "0.0.0.0/0"))
                                      .Select(r => new DiagnosticResult
@@ -464,12 +480,12 @@ public partial class DiagnosticEngine
     private async Task CheckClusterAccessAsync()
     {
         // Local users (pam/pve realm) without expiration and tokens without expiration are a security risk
-        var accessUsersTask = client.Access.Users.GetAsync();
-        var tfaEntriesTask = client.Access.Tfa.GetAsync();
-        var aclsTask = client.Access.Acl.GetAsync();
-        var groupsTask = client.Access.Groups.GetAsync();
-        var rolesTask = client.Access.Roles.GetAsync();
-        var domainsTask = client.Access.Domains.GetAsync();
+        var accessUsersTask = client.Access.Users.GetAsync().ToSafeEnum(_result, "access/users", DiagnosticResultContext.Cluster, "access users");
+        var tfaEntriesTask = client.Access.Tfa.GetAsync().ToSafeEnum(_result, "access/tfa", DiagnosticResultContext.Cluster, "TFA entries");
+        var aclsTask = client.Access.Acl.GetAsync().ToSafeEnum(_result, "access/acl", DiagnosticResultContext.Cluster, "ACL entries");
+        var groupsTask = client.Access.Groups.GetAsync().ToSafeEnum(_result, "access/groups", DiagnosticResultContext.Cluster, "access groups");
+        var rolesTask = client.Access.Roles.GetAsync().ToSafeEnum(_result, "access/roles", DiagnosticResultContext.Cluster, "access roles");
+        var domainsTask = client.Access.Domains.GetAsync().ToSafeEnum(_result, "access/domains", DiagnosticResultContext.Cluster, "access domains");
         await Task.WhenAll(accessUsersTask, tfaEntriesTask, aclsTask, groupsTask, rolesTask, domainsTask);
         var accessUsers = accessUsersTask.Result;
         var tfaEntries = tfaEntriesTask.Result;

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Common.cs
@@ -117,7 +117,9 @@ public partial class DiagnosticEngine
             {
                 foreach (var poolId in _clusterBackups.Where(a => a.Enabled && !string.IsNullOrWhiteSpace(a.Pool)).Select(a => a.Pool))
                 {
-                    var poolDetail = await client.Pools[poolId].GetAsync();
+                    var poolDetail = await client.Pools[poolId].GetAsync()
+                                           .ToSafeSingle(_result, $"pools/{poolId}", DiagnosticResultContext.Cluster, $"members of pool '{poolId}'");
+                    if (poolDetail == null) { continue; }
                     foundBackupConfig = poolDetail.Members.Any(a => a.ResourceType == ClusterResourceType.Vm && a.VmId == vmId);
                     if (foundBackupConfig) { break; }
                 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Container.cs
@@ -182,7 +182,8 @@ public partial class DiagnosticEngine
                                      lxcConfig,
                                      fetch.Pending,
                                      fetch.Snapshots,
-                                     await client.Nodes[item.Node].Lxc[item.VmId].Rrddata.GetAsync(settings.Lxc.Rrd.TimeFrame, settings.Lxc.Rrd.Consolidation),
+                                     await client.Nodes[item.Node].Lxc[item.VmId].Rrddata.GetAsync(settings.Lxc.Rrd.TimeFrame, settings.Lxc.Rrd.Consolidation)
+                                                 .ToSafeEnum(_result, id, DiagnosticResultContext.Lxc, $"RRD data for CT {item.VmId}"),
                                      DiagnosticResultContext.Lxc,
                                      item.Node,
                                      item.VmId,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Vm.cs
@@ -60,15 +60,15 @@ public partial class DiagnosticEngine
         // Build set of VM IDs managed by HA from already-loaded resources
         var haVmIds = _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
                                            && !string.IsNullOrWhiteSpace(a.HaState))
-                               .Select(a => a.VmId)
-                               .ToHashSet();
+                                .Select(a => a.VmId)
+                                .ToHashSet();
 
         // vCPU overcommit check — sum of vCPUs per node vs physical CPUs
         // CpuSize on node resource = physical CPU count; on VM resource = assigned vCPUs
         foreach (var nodeGroup in _resources.Where(a => a.ResourceType == ClusterResourceType.Vm
                                                        && a.VmType == VmType.Qemu
                                                        && !a.IsTemplate)
-                                           .GroupBy(a => a.Node))
+                                            .GroupBy(a => a.Node))
         {
             var nodeResource = _resources.FirstOrDefault(a => a.ResourceType == ClusterResourceType.Node
                                                              && a.Node == nodeGroup.Key);
@@ -541,7 +541,8 @@ public partial class DiagnosticEngine
                                      config,
                                      fetch.Pending,
                                      fetch.Snapshots,
-                                     await client.Nodes[item.Node].Qemu[item.VmId].Rrddata.GetAsync(settings.Qemu.Rrd.TimeFrame, settings.Qemu.Rrd.Consolidation),
+                                     await client.Nodes[item.Node].Qemu[item.VmId].Rrddata.GetAsync(settings.Qemu.Rrd.TimeFrame, settings.Qemu.Rrd.Consolidation)
+                                                 .ToSafeEnum(_result, id, DiagnosticResultContext.Qemu, $"RRD data for VM {item.VmId}"),
                                      DiagnosticResultContext.Qemu,
                                      item.Node,
                                      item.VmId,

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.cs
@@ -95,8 +95,10 @@ public partial class DiagnosticEngine(PveClient client, Settings settings, HttpC
             var pveMajorVersion = 8; // default to bookworm
             if (firstOnlineNode != null)
             {
-                var ver = await client.Nodes[firstOnlineNode.Node].Version.GetAsync();
-                _ = int.TryParse(ver.Version?.Split('.')[0], out pveMajorVersion);
+                var ver = await client.Nodes[firstOnlineNode.Node].Version.GetAsync()
+                                .ToSafeSingle(_result, firstOnlineNode.GetWebUrl(), DiagnosticResultContext.Node,
+                                              $"PVE version on node '{firstOnlineNode.Node}'");
+                if (ver != null) { _ = int.TryParse(ver.Version?.Split('.')[0], out pveMajorVersion); }
             }
 
             await FetchCveDataAsync(pveMajorVersion);


### PR DESCRIPTION
## Summary
The per-node and per-guest fetches were already wrapped in `ToSafe*` (PRs #44 / #46). Several cluster-level fetches were still nude — including the new ones added in #47 (`Access.Domains`, `Cluster.Tasks`, `Cluster.Log`) and the older `Access.Users/Tfa/Acl/Groups/Roles`, `Cluster.Status`, `Cluster.Firewall.*`, etc.

A single failing call there would still abort the whole analysis. This PR closes that gap.

### Wrapped
**Cluster.cs**
- `Cluster.Config.Nodes`, `Cluster.Backup` (bootstrap)
- `Cluster.Status` (quorum)
- `Cluster.Ha.Resources`, `Cluster.Ha.Status.Current`, `Cluster.Replication`
- `Cluster.Ha.Groups` (pre-PVE9)
- `Pools` (cluster-level)
- `Cluster.Firewall.Options`, `Cluster.Firewall.Rules`
- Per-node `Firewall.Options` inside `RunParallelAsync` (a faulty node is skipped, others continue)
- `Access.Users / Tfa / Acl / Groups / Roles / Domains` (the parallel batch)

**Other files**
- `DiagnosticEngine.cs` — `Nodes[].Version` (PVE major version detection)
- `Common.cs` — `Pools[poolId]` lookup during backup-config resolution
- `Vm.cs` / `Container.cs` — per-guest `Rrddata`

### Intentionally NOT wrapped
- **`nodeCompareData` fetch**: already protected coarsely (one bad call → the whole node is skipped with a finding). The downstream check loop uses `version / hosts / dns / aptVersions / status / aptRepositories / networks / time` together; fine-grained nullable propagation would touch ~20 sites with no real win.
- **`vmApi.Agent.Info.GetAsync`**: the silent `catch` there is the mechanism that drives `WG0004` ("Qemu Agent in guest not running"). Wrapping it would produce a duplicate `WG0042` alongside the legitimate finding.

CHANGELOG `[Unreleased]` updated.

## Test plan
- [ ] `dotnet test` — 66 tests still green.
- [ ] Revoke a permission to make any of the wrapped endpoints return 403 → analysis completes, single `WG0042` finding for that endpoint.
- [ ] Stop a node so its per-node `Firewall.Options` errors → only that node is missed, other nodes still produce `WN0001` if applicable.
- [ ] Healthy cluster: no `WG0042` noise.