### PR TITLE
fix(cve): NVD query + remove Debian Tracker (zero-match by design)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,12 @@
 
 ### CVE checks
 
-- `CN0014` / `WN0041` (Debian Security Tracker) — a CVE is no longer reported for a package that is already at or beyond the released fix. Removes most false positives on patched systems.
-- `CN0015` / `WN0042` (NVD) — the NVD query now targets Proxmox VE directly (CPE-based) instead of a generic keyword search, so no relevant historical CVE is missed and no unrelated product is reported.
-- Failures fetching CVE data now emit a `WG0042` warning instead of leaving the section silently empty.
-- CVE entries with no severity score or no description are skipped.
+- **Removed** the Debian Security Tracker check (`CN0014` / `WN0041`) and the `Cve.DebianTrackerEnabled` setting. PVE's `/apt/versions` API only exposes a curated list of Proxmox-distributed packages (`proxmox-ve`, `pve-manager`, kernel, `qemu-server`, …), which is not what the Debian Security Tracker indexes. The two sets do not overlap, so the check was producing zero findings by design. For a Debian-wide audit run `debsecan` directly on each node.
+- `CN0015` / `WN0042` (NVD) — the NVD query now uses `virtualMatchString` (instead of `cpeName` with a `*` version wildcard, which NVD rejects with 404), so the check actually runs and returns Proxmox VE CVEs across all versions.
+- NVD fetch failures now emit a `WG0042` warning instead of leaving the check silently empty.
+- NVD CVE entries with no CVSS score or no description are skipped.
+
+> **Migration:** if your `settings.json` contains `"DebianTrackerEnabled": true`, just remove that line. The rest of the `Cve` section keeps working as before.
 
 
 ## [2.3.0] — 2026-05-27

--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ cv4pve-diag @/etc/cv4pve/production.conf execute
 | Root filesystem usage              | WN0029        | Usage            | Warning/Critical | Node root filesystem usage above configured threshold                          |
 | SWAP usage above threshold         | WN0030        | Usage            | Warning/Critical | Node SWAP usage above configured threshold — indicates RAM pressure             |
 | Unknown resource type              | CU0001        | Status           | Critical         | A cluster resource with an unknown type was detected                           |
-| Open CVE on installed package      | WN0041/CN0014 | CVE              | Warning/Critical | Installed package has an open CVE in the Debian security tracker               |
 | Proxmox VE CVE                     | WN0042/CN0015 | CVE              | Warning/Critical | A known CVE affects the installed Proxmox VE version                           |
 
 </details>
@@ -471,9 +470,8 @@ cv4pve-diag --host=pve.local --api-token=user@realm!token=uuid --settings-file=s
   "MaxParallelRequests": 5, // global parallel API requests (1 = sequential)
   "ApiTimeout": 0,          // HTTP timeout in seconds (0 = 100s default)
   "Cve": {
-    "DebianTrackerEnabled": false, // check installed packages against Debian security advisories
     "NvdEnabled": false,           // check for CVEs specific to Proxmox VE (NVD API 2.0)
-    "MinCvssScore": 7.0,           // ignore CVEs below this CVSS score (NVD only)
+    "MinCvssScore": 7.0,           // ignore CVEs below this CVSS score
   },
 }
 ```
@@ -526,24 +524,7 @@ Parallelism means more simultaneous requests — if your cluster is slow or the 
 
 ## CVE Scanning
 
-cv4pve-diag can optionally check your cluster for known security vulnerabilities. Both sources are **disabled by default** and require internet access at runtime.
-
-### Debian Security Tracker
-
-Checks every installed package on each node against the Debian security advisory feed, automatically filtered to the Debian release that matches your PVE version (e.g. bookworm for PVE 8, bullseye for PVE 7).
-
-```jsonc
-"Cve": {
-  "DebianTrackerEnabled": true
-}
-```
-
-- Packages with open, high-severity vulnerabilities → **Critical** (`CN0014`)
-- Packages with open, medium or unrated vulnerabilities → **Warning** (`WN0041`)
-
-### NVD (Proxmox VE CVEs)
-
-Queries the NVD database for CVEs that specifically affect Proxmox VE. Only CVEs that apply to your installed version are reported. Requires no API key.
+cv4pve-diag can optionally check your cluster for Proxmox VE specific CVEs via the NVD (National Vulnerability Database) API. **Disabled by default**, requires internet access at runtime, no API key needed.
 
 ```jsonc
 "Cve": {
@@ -555,13 +536,16 @@ Queries the NVD database for CVEs that specifically affect Proxmox VE. Only CVEs
 - CVSS score ≥ 9.0 → **Critical** (`CN0015`)
 - CVSS score ≥ 7.0 → **Warning** (`WN0042`)
 
+Only CVEs that apply to your installed `pve-manager` version are reported (matched against the NVD version range).
+
+> **Scope.** This check covers Proxmox VE itself (`cpe:2.3:a:proxmox:virtual_environment`). For a Debian-wide system package audit run [`debsecan`](https://manpages.debian.org/bookworm/debsecan/debsecan.1.en.html) directly on each node — PVE's REST API does not expose the full installed package set, so it is not something diag can do remotely.
+
 ### Summary
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `Cve.DebianTrackerEnabled` | Check installed packages against Debian advisories | `false` |
 | `Cve.NvdEnabled` | Check for Proxmox VE CVEs via NVD | `false` |
-| `Cve.MinCvssScore` | Minimum CVSS score to report (NVD only) | `7.0` |
+| `Cve.MinCvssScore` | Minimum CVSS score to report | `7.0` |
 
 ---
 

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/DiagnosticEngine.Cve.cs
@@ -11,20 +11,7 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 
 public partial class DiagnosticEngine
 {
-    // PVE major version → Debian release name
-    private static readonly Dictionary<int, string> _pveToDebian = new()
-    {
-        { 9, "trixie"   },
-        { 8, "bookworm" },
-        { 7, "bullseye" },
-        { 6, "buster"   },
-    };
-
     private static readonly string[] _cvssMetricKeys = ["cvssMetricV31", "cvssMetricV30", "cvssMetricV2"];
-
-    // Debian Tracker: package → CVE → (status, urgency, fixed_version) — filtered to the detected release at parse time.
-    // FixedVersion is null when the tracker has no fix yet, "" when fixed in the base package, otherwise the version that closes the CVE.
-    private record DebianCveEntry(string Status, string Urgency, string? FixedVersion);
 
     // NVD CVE entry — only what we need
     private record NvdCveEntry(string Id,
@@ -34,71 +21,17 @@ public partial class DiagnosticEngine
                                string? VersionStart,
                                string? VersionEnd);
 
-    private Dictionary<string, Dictionary<string, DebianCveEntry>>? _debianCveData;
     private List<NvdCveEntry>? _nvdCveData;
 
     private async Task FetchCveDataAsync(int pveMajorVersion)
     {
-        var debianRelease = _pveToDebian.GetValueOrDefault(pveMajorVersion, "bookworm");
+        // pveMajorVersion is currently unused (the NVD query targets the product, not a release).
+        // Kept in the signature in case future CVE sources need it.
+        _ = pveMajorVersion;
 
         httpClient.DefaultRequestHeaders.UserAgent.TryParseAdd("cv4pve-diag/1.0");
 
-        var tasks = new List<Task>();
-
-        if (settings.Cve.DebianTrackerEnabled) { tasks.Add(FetchDebianCveAsync(debianRelease)); }
-        if (settings.Cve.NvdEnabled) { tasks.Add(FetchNvdCveAsync()); }
-
-        await Task.WhenAll(tasks);
-    }
-
-    private async Task FetchDebianCveAsync(string debianRelease)
-    {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
-        try
-        {
-            await using var stream = await httpClient.GetStreamAsync("https://security-tracker.debian.org/tracker/data/json", cts.Token);
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
-            var result = new Dictionary<string, Dictionary<string, DebianCveEntry>>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var pkg in doc.RootElement.EnumerateObject())
-            {
-                var cveMap = new Dictionary<string, DebianCveEntry>(StringComparer.OrdinalIgnoreCase);
-                foreach (var cve in pkg.Value.EnumerateObject())
-                {
-                    if (!cve.Value.TryGetProperty("releases", out var releases)) { continue; }
-
-                    // Filter at parse time — keep only the detected Debian release
-                    if (!releases.TryGetProperty(debianRelease, out var rel)) { continue; }
-
-                    var status = rel.TryGetProperty("status", out var s) ? s.GetString() ?? "" : "";
-                    if (status != "open") { continue; }
-
-                    var urgency = rel.TryGetProperty("urgency", out var u) ? u.GetString() ?? "" : "";
-                    if (urgency is "unimportant" or "end-of-life") { continue; }
-
-                    var fixedVersion = rel.TryGetProperty("fixed_version", out var fv) ? fv.GetString() : null;
-
-                    cveMap[cve.Name] = new DebianCveEntry(status, urgency, fixedVersion);
-                }
-                if (cveMap.Count > 0) { result[pkg.Name] = cveMap; }
-            }
-            _debianCveData = result;
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            // Surface the failure as a finding instead of silently leaving the check empty —
-            // an empty result would otherwise read as "no CVEs found", giving a false sense of safety.
-            _debianCveData = [];
-            _result.Add(new DiagnosticResult
-            {
-                Id = "cluster",
-                ErrorCode = DiagnosticSafeExtensions.ApiErrorCode,
-                Description = $"Unable to fetch Debian Security Tracker data: {ex.Message}",
-                Context = DiagnosticResultContext.Cluster,
-                SubContext = "ApiError",
-                Gravity = DiagnosticResultGravity.Warning,
-            });
-        }
+        if (settings.Cve.NvdEnabled) { await FetchNvdCveAsync(); }
     }
 
     private async Task FetchNvdCveAsync()
@@ -106,10 +39,12 @@ public partial class DiagnosticEngine
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
         try
         {
-            // Query by CPE (vs free-text keywordSearch=proxmox) so the server returns only
-            // Proxmox VE entries — no Salt/Jenkins/Foreman/Terraform noise to filter out client-side.
+            // Query by CPE prefix so the server returns only Proxmox VE entries (no Salt /
+            // Jenkins / Foreman / Terraform noise to filter out client-side).
+            // Uses virtualMatchString (not cpeName): cpeName requires a concrete version, while
+            // virtualMatchString allows matching all versions of the product.
             // resultsPerPage=2000 is the NVD maximum and comfortably covers all historical PVE CVEs.
-            await using var stream = await httpClient.GetStreamAsync("https://services.nvd.nist.gov/rest/json/cves/2.0?cpeName=cpe:2.3:a:proxmox:virtual_environment:*&resultsPerPage=2000", cts.Token);
+            await using var stream = await httpClient.GetStreamAsync("https://services.nvd.nist.gov/rest/json/cves/2.0?virtualMatchString=cpe:2.3:a:proxmox:virtual_environment&resultsPerPage=2000", cts.Token);
             using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cts.Token);
             var result = new List<NvdCveEntry>();
             if (!doc.RootElement.TryGetProperty("vulnerabilities", out var vulns)) { _nvdCveData = result; return; }
@@ -189,8 +124,8 @@ public partial class DiagnosticEngine
 
     // Pulls (versionStartIncluding, versionEndExcluding|versionEndIncluding) from the first
     // CPE entry that references proxmox:virtual_environment. The CPE filter is still needed
-    // even with cpeName= on the request: a CVE may include CPEs for other products too, and
-    // we must take the range from the right one.
+    // even with virtualMatchString= on the request: a CVE may include CPEs for other products too,
+    // and we must take the range from the right one.
     private static (string? Start, string? End) ExtractProxmoxVersionRange(JsonElement cve)
     {
         if (!cve.TryGetProperty("configurations", out var configs)) { return (null, null); }
@@ -218,76 +153,37 @@ public partial class DiagnosticEngine
 
     private void CheckNodeCve(string id, IEnumerable<NodeAptVersion> aptVersions)
     {
-        // Debian Security Tracker — data already filtered to the correct release at fetch time
-        if (settings.Cve.DebianTrackerEnabled && _debianCveData != null)
+        // NVD — Proxmox VE specific CVEs, already filtered by MinCvssScore at fetch time.
+        // Matched against the installed pve-manager version (the canonical PVE version marker).
+        if (!settings.Cve.NvdEnabled || _nvdCveData == null) { return; }
+
+        var pvePkg = aptVersions.FirstOrDefault(p => p.Package?.Equals("pve-manager", StringComparison.OrdinalIgnoreCase) is true);
+        var pveVerStr = pvePkg?.Version ?? "";
+
+        foreach (var cve in _nvdCveData)
         {
-            foreach (var pkg in aptVersions)
+            // Skip if installed pve-manager version is beyond the vulnerable range
+            if (!string.IsNullOrWhiteSpace(pveVerStr) && !string.IsNullOrWhiteSpace(cve.VersionEnd))
             {
-                if (string.IsNullOrWhiteSpace(pkg.Package) || string.IsNullOrWhiteSpace(pkg.Version)) { continue; }
-                if (!_debianCveData.TryGetValue(pkg.Package, out var cveMap)) { continue; }
-
-                foreach (var (cveId, entry) in cveMap)
-                {
-                    // The installed package may already be at or beyond the fixed version published
-                    // by Debian Security; in that case the CVE is closed for us, skip it.
-                    if (!string.IsNullOrWhiteSpace(entry.FixedVersion)
-                        && DebianVersion.Compare(pkg.Version, entry.FixedVersion) >= 0)
-                    {
-                        continue;
-                    }
-
-                    var gravity = entry.Urgency switch
-                    {
-                        "high" => DiagnosticResultGravity.Critical,
-                        "medium" => DiagnosticResultGravity.Warning,
-                        "not yet assigned" => DiagnosticResultGravity.Warning, // open CVE, fix not yet available
-                        _ => DiagnosticResultGravity.Info,
-                    };
-
-                    _result.Add(new DiagnosticResult
-                    {
-                        Id = id,
-                        ErrorCode = gravity == DiagnosticResultGravity.Critical ? "CN0014" : "WN0041",
-                        Description = $"Package '{pkg.Package}' ({pkg.Version}) has open CVE {cveId} (urgency: {entry.Urgency})",
-                        Context = DiagnosticResultContext.Node,
-                        SubContext = "CVE",
-                        Gravity = gravity,
-                    });
-                }
+                if (DebianVersion.Compare(pveVerStr, cve.VersionEnd) > 0) { continue; }
             }
-        }
 
-        // NVD — Proxmox VE specific CVE, already filtered by MinCvssScore at fetch time
-        if (settings.Cve.NvdEnabled && _nvdCveData != null)
-        {
-            var pvePkg = aptVersions.FirstOrDefault(p => p.Package?.Equals("pve-manager", StringComparison.OrdinalIgnoreCase) is true);
-            var pveVerStr = pvePkg?.Version ?? "";
-
-            foreach (var cve in _nvdCveData)
+            var gravity = cve.CvssScore switch
             {
-                // Skip if installed pve-manager version is beyond the vulnerable range
-                if (!string.IsNullOrWhiteSpace(pveVerStr) && !string.IsNullOrWhiteSpace(cve.VersionEnd))
-                {
-                    if (DebianVersion.Compare(pveVerStr, cve.VersionEnd) > 0) { continue; }
-                }
+                >= 9.0 => DiagnosticResultGravity.Critical,
+                >= 7.0 => DiagnosticResultGravity.Warning,
+                _ => DiagnosticResultGravity.Info,
+            };
 
-                var gravity = cve.CvssScore switch
-                {
-                    >= 9.0 => DiagnosticResultGravity.Critical,
-                    >= 7.0 => DiagnosticResultGravity.Warning,
-                    _ => DiagnosticResultGravity.Info,
-                };
-
-                _result.Add(new DiagnosticResult
-                {
-                    Id = id,
-                    ErrorCode = gravity == DiagnosticResultGravity.Critical ? "CN0015" : "WN0042",
-                    Description = $"Proxmox CVE {cve.Id} (CVSS: {cve.CvssScore:F1}, {cve.Severity}): {cve.Description}",
-                    Context = DiagnosticResultContext.Node,
-                    SubContext = "CVE",
-                    Gravity = gravity,
-                });
-            }
+            _result.Add(new DiagnosticResult
+            {
+                Id = id,
+                ErrorCode = gravity == DiagnosticResultGravity.Critical ? "CN0015" : "WN0042",
+                Description = $"Proxmox CVE {cve.Id} (CVSS: {cve.CvssScore:F1}, {cve.Severity}): {cve.Description}",
+                Context = DiagnosticResultContext.Node,
+                SubContext = "CVE",
+                Gravity = gravity,
+            });
         }
     }
 }

--- a/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
+++ b/src/Corsinvest.ProxmoxVE.Diagnostic.Api/SettingsCve.cs
@@ -11,16 +11,8 @@ namespace Corsinvest.ProxmoxVE.Diagnostic.Api;
 public class SettingsCve
 {
     /// <summary>
-    /// Enable Debian Security Tracker checks.
-    /// Downloads CVE data for all Debian packages installed on each node.
-    /// Covers system packages (kernel, qemu, lxc, openssl, ...).
-    /// </summary>
-    public bool DebianTrackerEnabled { get; set; }
-
-    /// <summary>
-    /// Enable NVD checks for Proxmox-specific CVE.
-    /// Queries NVD API once with keywordSearch=proxmox to find CVE affecting PVE directly.
-    /// Optional API key speeds up the request (free at https://nvd.nist.gov/developers/request-an-api-key).
+    /// Enable NVD checks for Proxmox VE specific CVEs.
+    /// Queries the NVD API once with a Proxmox VE CPE filter.
     /// </summary>
     public bool NvdEnabled { get; set; }
 


### PR DESCRIPTION
## Summary

### NVD: switch to `virtualMatchString`
The previous query used `cpeName=cpe:2.3:a:proxmox:virtual_environment:*` which NVD **rejects with HTTP 404** (cpeName forbids wildcards in the version component). The check was running but producing only a `WG0042` ApiError finding, never any `CN0015` / `WN0042`.

Now uses `virtualMatchString=cpe:2.3:a:proxmox:virtual_environment` (no version), which matches all PVE versions correctly. Verified on a real cluster: NVD returns 2 Proxmox VE CVE entries (CVSS ≥ 7), filtered by installed `pve-manager` version.

### Debian Tracker: removed (was useless)
PVE's `/apt/versions` API exposes only **Proxmox-distributed packages** (`proxmox-ve`, `pve-manager`, kernel, `qemu-server`, `lxcfs`, `ifupdown2`, …) — verified against the Perl source of [PVE/API2/APT.pm](https://git.proxmox.com/?p=pve-manager.git;a=blob_plain;f=PVE/API2/APT.pm;hb=HEAD).

These packages are **not indexed by the Debian Security Tracker** (which tracks Debian packages: `libc6`, `openssl`, `python3`, `samba`, …). The two sets do not overlap, so `CN0014` / `WN0041` were producing **zero findings by design**.

Verified on a real cluster:
- Debian tracker loaded: 896 packages with open CVEs
- Per-node scan: 77 / 69 Proxmox packages installed → **0 matches**

Removed:
- `FetchDebianCveAsync`, `DebianCveEntry`, `_debianCveData`
- `_pveToDebian` mapping table
- `DebianTrackerEnabled` setting
- Per-node Debian block in `CheckNodeCve`
- Related README section and check-table row

Kept: `DebianVersion` helper (still used by the NVD check for `versionEnd` comparison) and its 33 unit tests.

For a Debian-wide system package audit, users can run [`debsecan`](https://manpages.debian.org/bookworm/debsecan/debsecan.1.en.html) directly on each node — that surface is not exposed over the PVE REST API and is out of scope for diag.

### Migration
If `settings.json` contains `"DebianTrackerEnabled": true`, just remove that line. The rest of the `Cve` section keeps working.

## Test plan
- [ ] `dotnet test` — all 66 tests still green.
- [ ] Run with `NvdEnabled: true` on a cluster — `WG0042` no longer appears with a 404 from NVD.
- [ ] Run with `NvdEnabled: true` on a vulnerable `pve-manager` version — `CN0015` / `WN0042` findings produced for matching CVEs.
- [ ] Existing `DebianTrackerEnabled` in user settings is ignored (no crash, just unused field).